### PR TITLE
Dotify 3.0 bundles

### DIFF
--- a/modules/braille/maven/bom/pom.xml
+++ b/modules/braille/maven/bom/pom.xml
@@ -282,7 +282,7 @@
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.common</artifactId>
-                <version>2.1.0</version>
+                <version>2.2.0</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
@@ -297,22 +297,22 @@
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.formatter.impl</artifactId>
-                <version>2.6.0</version>
+                <version>2.7.0</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.task-api</artifactId>
-                <version>2.3.0</version>
+                <version>2.6.0</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.task-runner</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.0</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.task.impl</artifactId>
-                <version>2.8.0</version>
+                <version>2.15.0</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.dotify</groupId>

--- a/modules/braille/maven/bom/pom.xml
+++ b/modules/braille/maven/bom/pom.xml
@@ -277,7 +277,7 @@
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.api</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
@@ -297,7 +297,7 @@
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.formatter.impl</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.dotify</groupId>

--- a/modules/braille/maven/bom/pom.xml
+++ b/modules/braille/maven/bom/pom.xml
@@ -32,7 +32,7 @@
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
                 <artifactId>common-utils</artifactId>
-                <version>5.1.0</version>
+                <version>5.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
@@ -52,27 +52,27 @@
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
                 <artifactId>dotify-calabash</artifactId>
-                <version>2.0.1</version>
+                <version>2.1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
                 <artifactId>dotify-core</artifactId>
-                <version>2.0.1</version>
+                <version>2.1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
                 <artifactId>dotify-formatter</artifactId>
-                <version>1.11.1</version>
+                <version>1.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
                 <artifactId>dotify-saxon</artifactId>
-                <version>2.1.1</version>
+                <version>2.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
                 <artifactId>dotify-utils</artifactId>
-                <version>2.0.0</version>
+                <version>2.1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
@@ -203,7 +203,7 @@
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
                 <artifactId>texhyph-core</artifactId>
-                <version>4.0.1</version>
+                <version>4.1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.pipeline.modules.braille</groupId>
@@ -277,47 +277,47 @@
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.api</artifactId>
-                <version>2.10.0</version>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.common</artifactId>
-                <version>2.2.0</version>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.translator.impl</artifactId>
-                <version>2.3.0</version>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.hyphenator.impl</artifactId>
-                <version>2.0.1</version>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.formatter.impl</artifactId>
-                <version>2.7.0</version>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.task-api</artifactId>
-                <version>2.6.0</version>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.task-runner</artifactId>
-                <version>1.2.0</version>
+                <version>2.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.task.impl</artifactId>
-                <version>2.15.0</version>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.daisy.dotify</groupId>
                 <artifactId>dotify.text.impl</artifactId>
-                <version>2.0.0</version>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>com.googlecode.texhyphj</groupId>

--- a/modules/braille/pipeline-braille-utils/common-utils/pom.xml
+++ b/modules/braille/pipeline-braille-utils/common-utils/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>common-utils</artifactId>
-  <version>5.1.1-SNAPSHOT</version>
+  <version>5.2.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DP2 Braille Modules :: common-utils</name>

--- a/modules/braille/pipeline-braille-utils/dotify-utils/dotify-calabash/pom.xml
+++ b/modules/braille/pipeline-braille-utils/dotify-utils/dotify-calabash/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>dotify-calabash</artifactId>
-  <version>2.0.2-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DP2 Braille Modules :: dotify-utils :: dotify-calabash</name>

--- a/modules/braille/pipeline-braille-utils/dotify-utils/dotify-calabash/src/main/java/org/daisy/pipeline/braille/dotify/calabash/impl/FileToOBFLStep.java
+++ b/modules/braille/pipeline-braille-utils/dotify-utils/dotify-calabash/src/main/java/org/daisy/pipeline/braille/dotify/calabash/impl/FileToOBFLStep.java
@@ -1,5 +1,8 @@
 package org.daisy.pipeline.braille.dotify.calabash.impl;
 
+import static org.daisy.pipeline.braille.common.Query.util.query;
+import static org.daisy.pipeline.braille.common.util.Files.asFile;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -8,13 +11,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.xml.transform.stream.StreamSource;
 
 import org.daisy.common.xproc.calabash.XProcStepProvider;
+import org.daisy.dotify.api.identity.IdentityProviderService;
+import org.daisy.dotify.api.tasks.AnnotatedFile;
+import org.daisy.dotify.api.tasks.DefaultAnnotatedFile;
 import org.daisy.dotify.api.tasks.InternalTask;
 import org.daisy.dotify.api.tasks.TaskGroupFactoryMakerService;
-import org.daisy.dotify.api.tasks.TaskGroupSpecification;
+import org.daisy.dotify.api.tasks.TaskGroupInformation;
 import org.daisy.dotify.api.tasks.TaskSystem;
 import org.daisy.dotify.api.tasks.TaskSystemException;
 import org.daisy.dotify.api.tasks.TaskSystemFactoryException;
@@ -22,16 +29,11 @@ import org.daisy.dotify.api.tasks.TaskSystemFactoryMakerService;
 import org.daisy.dotify.common.xml.XMLTools;
 import org.daisy.dotify.common.xml.XMLToolsException;
 import org.daisy.dotify.tasks.runner.TaskRunner;
-
 import org.daisy.pipeline.braille.common.Query.Feature;
-import static org.daisy.pipeline.braille.common.Query.util.query;
-import static org.daisy.pipeline.braille.common.util.Files.asFile;
-
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,20 +65,25 @@ public class FileToOBFLStep extends DefaultStep {
     private static final QName _rowgap = new QName("rowgap");
     private static final QName _splitterMax = new QName("splitterMax");
     private static final QName _identifier = new QName("identifier");
+    
+    private static final Logger logger = LoggerFactory.getLogger(FileToOBFLStep.class);
 	
 	private WritablePipe result = null;
-	private final Map<String,String> parameters = new HashMap<String,String>();
+	private final Map<String,String> parameters = new HashMap<>();
 	
 	private final TaskSystemFactoryMakerService taskSystemFactoryService;
 	private final TaskGroupFactoryMakerService taskGroupFactoryService;
-	
+	private final IdentityProviderService identityService;
+
 	public FileToOBFLStep(XProcRuntime runtime,
 	                      XAtomicStep step,
 	                      TaskSystemFactoryMakerService taskSystemFactoryService,
-	                      TaskGroupFactoryMakerService taskGroupFactoryService) {
+	                      TaskGroupFactoryMakerService taskGroupFactoryService,
+	                      IdentityProviderService identityService) {
 		super(runtime, step);
 		this.taskSystemFactoryService = taskSystemFactoryService;
 		this.taskGroupFactoryService = taskGroupFactoryService;
+		this.identityService = identityService;
 	}
 	
 	@Override
@@ -135,9 +142,8 @@ public class FileToOBFLStep extends DefaultStep {
 			
 			params.putAll(parameters);
 			String locale = getOption(_locale, Locale.getDefault().toString());
-			InputStream resultStream = convert(
-					newTaskSystem(locale, getOption(_format, "obfl")),
-					inputFile, locale, params);
+			String outputFormat = getOption(_format, "obfl");
+			InputStream resultStream = convert(inputFile, outputFormat, locale, params);
 			
 			// Write result
 			result.write(runtime.getProcessor().newDocumentBuilder().build(new StreamSource(resultStream)));
@@ -155,28 +161,32 @@ public class FileToOBFLStep extends DefaultStep {
 		}
 	}
 		
-	private InputStream convert(TaskSystem system, File src, String locale, Map<String, Object> params) throws TaskSystemFactoryException, TaskSystemException, IOException {
+	private InputStream convert(File input, String outputFormat, String locale, Map<String, Object> params) throws TaskSystemFactoryException, TaskSystemException, IOException {
 		
 		// FIXME: see https://github.com/joeha480/dotify/issues/205
-		String inputFormat; {
-			inputFormat = "";
-			String inp = src.getName();
-			int inx = inp.lastIndexOf('.');
-			if (inx > -1) {
-				inputFormat = inp.substring(inx + 1);
-				if (!taskGroupFactoryService.listSupportedSpecifications().contains(new TaskGroupSpecification(inputFormat, "obfl", locale))) {
-					logger.debug("No input factory for " + inputFormat);
-					// attempt to detect a supported type
-					try {
-						if (XMLTools.isWellformedXML(src)) {
-							inputFormat = "xml";
-							logger.info("Input is well-formed xml."); }}
-					catch (XMLToolsException e) {
-						e.printStackTrace(); }}
-				else
-					logger.info("Found an input factory for " + inputFormat); }}
+		AnnotatedFile ai = identityService.identify(input);
+
+		String inputFormat = getFormatString(ai);
+		if (!supportsInputFormat(inputFormat, taskGroupFactoryService.listAll())) {
+			logger.debug("No input factory for " + inputFormat);
+			logger.info("Note, the following detection code has been deprected. In future versions, an exception will be thrown if this point is reached."
+						+ " To avoid this, use the IdentifierFactory interface to implement a detector for the file type.");
+			// attempt to detect a supported type
+			try {
+				if (XMLTools.isWellformedXML(ai.getFile())) {
+					ai = DefaultAnnotatedFile.with(ai).extension("xml").build();
+					inputFormat = ai.getExtension();
+					logger.info("Input is well-formed xml."); }}
+			catch (XMLToolsException e) {
+				logger.info("File is not well-formed xml: " + ai.getFile(), e);
+			}
+		} else {
+			logger.info("Found an input factory for " + inputFormat);
+		}
+
 		params.put("inputFormat", inputFormat);
-		params.put("input", src.getAbsolutePath());
+		params.put("input", ai.getFile().getAbsolutePath());
+		TaskSystem system = newTaskSystem(inputFormat, outputFormat, locale);
 		List<InternalTask> tasks = system.compile(params);
 		
 		// Create a destination file
@@ -185,14 +195,37 @@ public class FileToOBFLStep extends DefaultStep {
 		
 		// Run tasks
 		TaskRunner runner = TaskRunner.withName("dotify:file-to-obfl").build();
-		runner.runTasks(src, dest, tasks);
+		runner.runTasks(ai, dest, tasks);
 		
 		// Return stream
 		return new FileInputStream(dest);
 	}
+	
+	private static boolean supportsInputFormat(String inputFormat, Set<TaskGroupInformation> specs) {
+		for (TaskGroupInformation s : specs) {
+			if (s.getInputFormat().equals(inputFormat)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	private static String getFormatString(AnnotatedFile f) {
+		// FIXME: see https://github.com/joeha480/dotify/issues/205
 
-	private TaskSystem newTaskSystem(String locale, String format) throws TaskSystemFactoryException {
-		return taskSystemFactoryService.newTaskSystem(locale, format);
+		if (f.getFormatName()!=null) {
+			return f.getFormatName();
+		} else if (f.getExtension()!=null) {
+			return f.getExtension();
+		} else if (f.getMediaType()!=null) {
+			return f.getMediaType();
+		} else {
+			return null;
+		}
+	}
+
+	private TaskSystem newTaskSystem(String inputFormat, String outputFormat, String locale) throws TaskSystemFactoryException {
+		return taskSystemFactoryService.newTaskSystem(inputFormat, outputFormat, locale);
 	}
 	
 	@Component(
@@ -204,11 +237,12 @@ public class FileToOBFLStep extends DefaultStep {
 		
 		@Override
 		public XProcStep newStep(XProcRuntime runtime, XAtomicStep step) {
-			return new FileToOBFLStep(runtime, step, taskSystemFactoryService, taskGroupFactoryService);
+			return new FileToOBFLStep(runtime, step, taskSystemFactoryService, taskGroupFactoryService, identityService);
 		}
 		
 		private TaskSystemFactoryMakerService taskSystemFactoryService = null;
 		private TaskGroupFactoryMakerService taskGroupFactoryService = null;
+		private IdentityProviderService identityService = null;
 		
 		@Reference(
 			name = "TaskSystemFactoryMakerService",
@@ -229,8 +263,16 @@ public class FileToOBFLStep extends DefaultStep {
 		protected void bindTaskGroupFactoryMakerService(TaskGroupFactoryMakerService service) {
 			taskGroupFactoryService = service;
 		}
+		
+		@Reference(
+			name = "IdentityProviderService",
+			service = IdentityProviderService.class,
+			cardinality = ReferenceCardinality.MANDATORY,
+			policy = ReferencePolicy.STATIC
+		)
+		protected void bindIdentityProviderService(IdentityProviderService service) {
+			identityService = service;
+		}
 	}
-	
-	private static final Logger logger = LoggerFactory.getLogger(FileToOBFLStep.class);
 	
 }

--- a/modules/braille/pipeline-braille-utils/dotify-utils/dotify-core/pom.xml
+++ b/modules/braille/pipeline-braille-utils/dotify-utils/dotify-core/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>dotify-core</artifactId>
-  <version>2.0.2-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DP2 Braille Modules :: dotify-utils :: dotify-core</name>

--- a/modules/braille/pipeline-braille-utils/dotify-utils/dotify-formatter/pom.xml
+++ b/modules/braille/pipeline-braille-utils/dotify-utils/dotify-formatter/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   
   <artifactId>dotify-formatter</artifactId>
-  <version>1.11.2-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
   
   <name>DP2 Braille Modules :: dotify-utils :: dotify-formatter</name>

--- a/modules/braille/pipeline-braille-utils/dotify-utils/dotify-saxon/pom.xml
+++ b/modules/braille/pipeline-braille-utils/dotify-utils/dotify-saxon/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>dotify-saxon</artifactId>
-  <version>2.1.2-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DP2 Braille Modules :: dotify-utils :: dotify-saxon</name>

--- a/modules/braille/pipeline-braille-utils/dotify-utils/dotify-utils/pom.xml
+++ b/modules/braille/pipeline-braille-utils/dotify-utils/dotify-utils/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>dotify-utils</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DP2 Braille Modules :: dotify-utils :: dotify-utils</name>

--- a/modules/braille/pipeline-braille-utils/texhyph-utils/texhyph-core/pom.xml
+++ b/modules/braille/pipeline-braille-utils/texhyph-utils/texhyph-core/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>texhyph-core</artifactId>
-  <version>4.0.2-SNAPSHOT</version>
+  <version>4.1.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DP2 Braille Modules :: texhyph-utils :: texhyph-core</name>


### PR DESCRIPTION
Updates dotify bundles to 3.0 versions. Note that, due to OSGi version range requirements, other bundles using the dotify bundles has to be updated as well. Therefore I have "unpinned" these, but you may do with them as you wish.