### PR TITLE
Fix p:validate-with-xsd

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>org.daisy.pipeline</groupId>
         <artifactId>framework-bom</artifactId>
-        <version>1.10.3</version>
+        <version>1.10.4-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/framework/bom/pom.xml
+++ b/framework/bom/pom.xml
@@ -43,7 +43,7 @@
 
     <!-- Dependencies Versions -->
     <benchmark.version>0.7.2</benchmark.version>
-    <calabash.version>1.1.9-p1-95</calabash.version>
+    <calabash.version>1.1.9-p2-95-SNAPSHOT</calabash.version>
     <commons.codec.version>1.6</commons.codec.version>
     <commons.fileupload.version>1.3</commons.fileupload.version>
     <commons.io.version>2.3</commons.io.version>

--- a/framework/calabash-adapter/src/main/java/org/daisy/common/xproc/calabash/impl/CalabashXProcPipeline.java
+++ b/framework/calabash-adapter/src/main/java/org/daisy/common/xproc/calabash/impl/CalabashXProcPipeline.java
@@ -242,11 +242,9 @@ public class CalabashXProcPipeline implements XProcPipeline {
 			pipeline.xpipe.run();
                 //propagate possible errors
 		} catch (Exception e) {
-                        pipeline.runtime.close();
                         throw new RuntimeException(e);
 
 		} catch (OutOfMemoryError e) {//this one needs it's own catch!
-                        pipeline.runtime.close();
                         throw new RuntimeException(e);
 		}finally{
                         pipeline.runtime.close();

--- a/libs/com.xmlcalabash/gradle.properties
+++ b/libs/com.xmlcalabash/gradle.properties
@@ -1,5 +1,5 @@
-version=1.1.9-p1
-snapshot=
+version=1.1.9-p2
+snapshot=-SNAPSHOT
 docsVersion=1.1.8
 builtBy=Norman Walsh
 
@@ -15,4 +15,4 @@ testsADoc=test/report.adoc
 testsFailADoc=test/report-fail.adoc
 
 // for super project
-distVersion=1.1.9-p1-95
+distVersion=1.1.9-p2-95-SNAPSHOT

--- a/libs/com.xmlcalabash/src/main/java/com/xmlcalabash/library/ValidateWithXSD.java
+++ b/libs/com.xmlcalabash/src/main/java/com/xmlcalabash/library/ValidateWithXSD.java
@@ -116,12 +116,11 @@ public class ValidateWithXSD extends DefaultStep {
         super.run();
 
         Processor proc = runtime.getProcessor();
-        SchemaManager manager = proc.getSchemaManager();
-
-        if (manager == null) {
-            validateWithXerces();
-        } else {
+        if (proc.isSchemaAware()) {
+            SchemaManager manager = proc.getSchemaManager();
             validateWithSaxonSA(manager);
+        } else {
+            validateWithXerces();
         }
     }
 

--- a/modules/scripts/dtbook-to-epub3/src/test/resources/minimal.xml
+++ b/modules/scripts/dtbook-to-epub3/src/test/resources/minimal.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE dtbook PUBLIC "-//NISO//DTD dtbook 2005-3//EN" "http://www.daisy.org/z3986/2005/dtbook-2005-3.dtd">
-<dtbook xmlns="http://www.daisy.org/z3986/2005/dtbook/" xml:lang="en">
+<dtbook xmlns="http://www.daisy.org/z3986/2005/dtbook/" xml:lang="en" version="2005-3">
   <head>
     <meta name="dtb:uid" content="CECIREADER-TEST-CD46505C-6FD0-11E4-B2F6-BBE73AE121C6"/>
     <meta name="dc:Title" content="Minimal DTBook"/>

--- a/modules/scripts/parent/pom.xml
+++ b/modules/scripts/parent/pom.xml
@@ -76,7 +76,7 @@
       <dependency>
         <groupId>org.daisy.pipeline.build</groupId>
         <artifactId>modules-test-helper</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/utils/build-utils/modules-test-helper/pom.xml
+++ b/utils/build-utils/modules-test-helper/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.daisy.pipeline</groupId>
       <artifactId>pax-exam-helper</artifactId>
-      <version>2.2.0</version>
+      <version>2.2.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.daisy.xprocspec</groupId>

--- a/utils/build-utils/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
+++ b/utils/build-utils/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
@@ -533,15 +533,23 @@ public abstract class Options {
 								if (b.startLevel > 0)
 									startLevel = b.startLevel;
 								break; }
-						if (versionAsInProject
-						    && !a.getBaseVersion().equals(MavenUtils.asInProject().getVersion(groupId, artifactId))) {
-							MavenBundle b = new MavenBundle(a, true);
-							logger.info("Forcing transitive dependency \"" + artifactCoords(b.asArtifact()) + "\" (version as in project) "
-							            + "because it would otherwise resolve to version \"" + a.getBaseVersion() + "\" "
-							            + "(via \"" + artifactCoords(parent) + "\")");
-							b.startLevel(startLevel);
-							fromBundles.add(b);
-							return false; }
+						String versionInProject; {
+							versionInProject = null;
+							try {
+								versionInProject = MavenUtils.asInProject().getVersion(groupId, artifactId); }
+							catch (RuntimeException e) {
+								logger.info("Can not find version of transitive dependency " + groupId + ":" + artifactId
+								            + " in project. Assuming it was explicitly excluded, therefore ignoring it.");
+								return true; }}
+						if (versionAsInProject) {
+							if (!a.getBaseVersion().equals(versionInProject)) {
+								MavenBundle b = new MavenBundle(a, true);
+								logger.info("Forcing transitive dependency \"" + artifactCoords(b.asArtifact()) + "\""
+								            + " (version as in project) because it would otherwise resolve to version \""
+								            + a.getBaseVersion() + "\" (via \"" + artifactCoords(parent) + "\")");
+								b.startLevel(startLevel);
+								fromBundles.add(b);
+								return false; }}
 						MavenBundle b = new MavenBundle(a);
 						if (noStart)
 							b.noStart();


### PR DESCRIPTION
p:validate-with-xsd is broken in v1.10.2. See https://github.com/daisy/pipeline-scripts/issues/82#issuecomment-325612034. It seems that this was a bug in XMLCalabash.