### PR TITLE
[website] fix build error: 'No such file or directory'

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -1,4 +1,5 @@
 JEKYLL_SRC_DIR := src
+SHELL := bash
 JEKYLL_SRC_FILES_CONTENT := $(shell find $(JEKYLL_SRC_DIR)/{_wiki,_wiki_gui,_wiki_webui} -type f -not -name '_Sidebar.md' -not -name '*.png' )
 JEKYLL_SRC_FILES_MUSTACHE := $(shell find $(JEKYLL_SRC_DIR)/_data/_spines/ -type f -name '*.yml')
 JEKYLL_SRC_FILES_OTHER := $(filter-out $(JEKYLL_SRC_FILES_CONTENT) $(JEKYLL_SRC_FILES_MUSTACHE),\


### PR DESCRIPTION
Fixed a build error for the website Makefile.
