### PR TITLE
Fix webui packaging

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -1,4 +1,5 @@
 JEKYLL_SRC_DIR := src
+SHELL := bash
 JEKYLL_SRC_FILES_CONTENT := $(shell find $(JEKYLL_SRC_DIR)/{_wiki,_wiki_gui,_wiki_webui} -type f -not -name '_Sidebar.md' -not -name '*.png' )
 JEKYLL_SRC_FILES_MUSTACHE := $(shell find $(JEKYLL_SRC_DIR)/_data/_spines/ -type f -name '*.yml')
 JEKYLL_SRC_FILES_OTHER := $(filter-out $(JEKYLL_SRC_FILES_CONTENT) $(JEKYLL_SRC_FILES_MUSTACHE),\

--- a/webui/README.md
+++ b/webui/README.md
@@ -10,14 +10,9 @@ This project provides a Web User Interface for the DAISY Pipeline 2, developed w
 
 ### 1. Prepare the release
 
-The Web UI is versioned based on git tags. If you're on the `v2.0.0` tag,
-then the version used in the build will be `2.0.0`. If you're one commit
-ahead of `v2.0.0`, the version will be a SNAPSHOT version on the format
-`2.0.0-[commits ahead]-[commit hash]SNAPSHOT`.
-
-If you're making a release version (not a snapshot version),
-make sure that your current commit has a git tag and that
-there are no changes in your project directory (staged or unstaged).
+In `build.sbt`, update the `version := "..."`.
+The versioning should follow semantic versioning rules.
+Snapshots should have a `-SNAPSHOT` version suffix.
 
 ### 2. Perform the release
 
@@ -102,3 +97,5 @@ credentials += Credentials("Sonatype Nexus Repository Manager",
 ### 3. Prepare for the next development iteration
 
 Merge with the `master` branch if necessary.
+
+Add a `-SNAPSHOT` suffix to the version in `build.sbt`.

--- a/webui/build.sbt
+++ b/webui/build.sbt
@@ -6,8 +6,7 @@ import com.typesafe.sbt.packager.windows.WixHelper
 
 organization := "org.daisy.pipeline"
 name := "webui"
-versionWithGit
-git.useGitDescribe := true
+version := "2.5.2-SNAPSHOT"
 
 organizationName := "The DAISY Consortium"
 organizationHomepage := Some(url("http://daisy.org"))

--- a/webui/project/plugins.sbt
+++ b/webui/project/plugins.sbt
@@ -26,9 +26,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.6")
 // Eclipse
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "4.0.0")
 
-// Use git tags to version this project
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
-
 // Use this in order to enable sbt-native-packager in the project
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.0-RC2")
 


### PR DESCRIPTION
Versioning of the webui doesn't work since the git tags are in the [daisy/pipeline-webui](github.com/daisy/pipeline) repo. So this changes it so that the webui is versioned explicitly instead.

Corresponding commit in the webui repo: https://github.com/daisy/pipeline-webui/commit/9530f89d114fe9fc37ac05fbf09561e7c0e60ceb

Branch also contains: #518 
