### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:16.04
+
+LABEL maintainer="jostein@nlb.no"
+
+WORKDIR /root/
+
+# Install dependencies
+RUN sed -i.bak 's/main$/main universe/' /etc/apt/sources.list
+RUN apt-get update && apt-get install -y locales && apt-get clean
+RUN locale-gen en_US en_US.UTF-8
+
+# Install Java
+RUN apt-get update && apt-get install -y openjdk-8-jdk && apt-get clean
+
+# Install other dependencies
+RUN apt-get update && apt-get install -y software-properties-common build-essential wget zip unzip git maven gradle golang libxml2-utils pcregrep && apt-get clean
+RUN apt-get update && apt-get install -y ruby ruby-dev zlib1g-dev && apt-get clean
+RUN gem install jekyll sparql rdf-turtle rdf-rdfa commaparty nokogiri mustache github-markup coderay
+
+# Initialize git repository and store hash of current git commit as an environment variable
+RUN mkdir -p /tmp/pipeline/.git/objects
+ADD .git/refs /tmp/pipeline/.git/refs
+ADD .git/HEAD /tmp/pipeline/.git/HEAD
+ADD .git/config /tmp/pipeline/.git/config
+RUN git --git-dir=/tmp/pipeline/.git rev-parse HEAD | sed 's/^/export SOURCE_COMMIT=/' | tee -a .bashrc >> .profile
+RUN mkdir -p pipeline && cd pipeline && git init
+RUN cp /tmp/pipeline/.git/config pipeline/.git/
+RUN cd pipeline && git remote | grep '/' | while read remote; do git remote remove $remote ; done
+RUN rm /tmp/pipeline -rf
+
+# Fetch, build and install Pipeline 2
+# (and run build commands with bash)
+RUN echo '#!/bin/bash -e -x\n\
+    cd ~/pipeline \n\
+    git fetch --all \n\
+    . /root/.profile \n\
+    git checkout $SOURCE_COMMIT \n\
+    make dist-deb \n\
+    tail -f maven.log & \n\
+    make dist-webui-deb \n\
+    DEBIAN_FRONTEND=noninteractive dpkg -i *.deb \n\
+    apt-get update && apt-get -f install && apt-get clean \n\
+    service daisy-pipeline2 stop \n\
+    service daisy-pipeline2-webui stop \n\
+    cd ~ \n\
+    rm pipeline -rf\n'\
+    >> /tmp/run.sh && \
+    sh /tmp/run.sh && \
+    rm /tmp/run.sh
+# in case the webui service didn't shut down properly:
+RUN rm /run/daisy-pipeline2-webui/play.pid
+
+EXPOSE 8181
+EXPOSE 9000
+
+# By default, start the Pipeline 2 Engine and Web UI when the container is started
+CMD service daisy-pipeline2 start && \
+    service daisy-pipeline2-webui start && \
+    bash

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,4 +1,5 @@
 JEKYLL_SRC_DIR := src
+SHELL := bash
 JEKYLL_SRC_FILES_CONTENT := $(shell find $(JEKYLL_SRC_DIR)/{_wiki,_wiki_gui,_wiki_webui} -type f -not -name '_Sidebar.md' -not -name '*.png' )
 JEKYLL_SRC_FILES_MUSTACHE := $(shell find $(JEKYLL_SRC_DIR)/_data/_spines/ -type f -name '*.yml')
 JEKYLL_SRC_FILES_OTHER := $(filter-out $(JEKYLL_SRC_FILES_CONTENT) $(JEKYLL_SRC_FILES_MUSTACHE),\

--- a/webui/README.md
+++ b/webui/README.md
@@ -10,14 +10,9 @@ This project provides a Web User Interface for the DAISY Pipeline 2, developed w
 
 ### 1. Prepare the release
 
-The Web UI is versioned based on git tags. If you're on the `v2.0.0` tag,
-then the version used in the build will be `2.0.0`. If you're one commit
-ahead of `v2.0.0`, the version will be a SNAPSHOT version on the format
-`2.0.0-[commits ahead]-[commit hash]SNAPSHOT`.
-
-If you're making a release version (not a snapshot version),
-make sure that your current commit has a git tag and that
-there are no changes in your project directory (staged or unstaged).
+In `build.sbt`, update the `version := "..."`.
+The versioning should follow semantic versioning rules.
+Snapshots should have a `-SNAPSHOT` version suffix.
 
 ### 2. Perform the release
 
@@ -102,3 +97,5 @@ credentials += Credentials("Sonatype Nexus Repository Manager",
 ### 3. Prepare for the next development iteration
 
 Merge with the `master` branch if necessary.
+
+Add a `-SNAPSHOT` suffix to the version in `build.sbt`.

--- a/webui/build.sbt
+++ b/webui/build.sbt
@@ -6,8 +6,7 @@ import com.typesafe.sbt.packager.windows.WixHelper
 
 organization := "org.daisy.pipeline"
 name := "webui"
-versionWithGit
-git.useGitDescribe := true
+version := "2.5.2-SNAPSHOT"
 
 organizationName := "The DAISY Consortium"
 organizationHomepage := Some(url("http://daisy.org"))

--- a/webui/project/plugins.sbt
+++ b/webui/project/plugins.sbt
@@ -26,9 +26,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.6")
 // Eclipse
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "4.0.0")
 
-// Use git tags to version this project
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
-
 // Use this in order to enable sbt-native-packager in the project
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.0-RC2")
 


### PR DESCRIPTION
Added a Dockerfile that builds the current commit.

The image is currently 1,7 GB in size. I've tried to reduce the size of the image by
cloning, building, installing, and removing the cloned repo in a single docker `RUN` step.
However, this introduces a limitation: the Dockerfile retrieves the current commit (`git rev-parse HEAD`)
from the remote, which means that any local changes won't be included in the build.
A simpler alternative would be to `ADD` all the files in the current repository to the image,
which would allow you to build local changes; but that might increase the size of the image.
So if this is a problematic limitation, we could try `ADD`ing the repo into the image.

Branch also contains: #518 #519
