### PR TITLE
make SKIP_RELEASE=true

### DIFF
--- a/.make/gradle-release.sh
+++ b/.make/gradle-release.sh
@@ -2,6 +2,10 @@
 set -e
 set -o pipefail
 
+if [ "$SKIP_RELEASE" = "true" ]; then
+    exit 0
+fi
+
 make_cmd="make"
 if [[ -n $MAKEFLAGS ]]; then
     make_cmd+=" "

--- a/.make/mvn-release.sh
+++ b/.make/mvn-release.sh
@@ -2,6 +2,10 @@
 set -e
 set -o pipefail
 
+if [ "$SKIP_RELEASE" = "true" ]; then
+    exit 0
+fi
+
 make_cmd="make"
 if [[ -n $MAKEFLAGS ]]; then
     make_cmd+=" "


### PR DESCRIPTION
This is to avoid errors like this during development or on CI servers:

```
[INFO]
------------------------------------------------------------------------
[INFO] Building braille-css 1.13.1-SNAPSHOT
[INFO]
------------------------------------------------------------------------
[WARNING]
/tmp/pipeline2/libs/braille-css/src/main/java/org/daisy/braille/css/RuleVolume.java:
/tmp/pipeline2/libs/braille-css/src/main/java/org/daisy/braille/css/RuleVolume.java
uses unchecked or unsafe operations.
[WARNING]
/tmp/pipeline2/libs/braille-css/src/main/java/org/daisy/braille/css/RuleVolume.java:
Recompile with -Xlint:unchecked for details.
--> test -e
.maven-workspace/org/daisy/braille/braille-css/1.13.1-SNAPSHOT/braille-css-1.13.1-SNAPSHOT.jar
--> bash .make/gradle-release.sh libs/braille-utils/braille-utils.api
Release libs/braille-utils/braille-utils.api manually. Then, run `make
-s dist-zip-linux' again to continue.

action suspended...
Makefile:253: recipe for target '.group-eval' failed
make: *** [.group-eval] Error 100
```
