### PR TITLE
daisy/pipeline-tasks#125 - compliance to epub 3.2 specification

### DIFF
--- a/modules/common/html-utils/src/main/resources/META-INF/catalog.xml
+++ b/modules/common/html-utils/src/main/resources/META-INF/catalog.xml
@@ -4,8 +4,6 @@
           uri="../xml/xproc/html-library.xpl"/>
      <uri name="http://www.daisy.org/pipeline/modules/html-utils/library.xsl"
           uri="../xml/xslt/uri-functions.xsl"/>
-     <uri name="http://www.daisy.org/pipeline/modules/html-utils/html5-outliner.xsl"
-          uri="../xml/xslt/html5-outliner.xsl"/>
      <uri name="http://www.daisy.org/pipeline/modules/html-utils/html5-upgrade.xsl"
           uri="../xml/xslt/html5-upgrade.xsl"/>
      <uri name="http://www.daisy.org/pipeline/modules/html-utils/html-id-fixer.xsl"

--- a/modules/common/html-utils/src/main/resources/xml/xproc/html-library.xpl
+++ b/modules/common/html-utils/src/main/resources/xml/xproc/html-library.xpl
@@ -4,5 +4,6 @@
     <p:import href="html-load.xpl"/>
     <p:import href="html-chunker.xpl"/>
     <p:import href="html-to-fileset.xpl"/>
+    <p:import href="html-outline.xpl"/>
 
 </p:library>

--- a/modules/common/html-utils/src/main/resources/xml/xproc/html-outline.xpl
+++ b/modules/common/html-utils/src/main/resources/xml/xproc/html-outline.xpl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
+                type="px:html-outline"
+                version="1.0">
+
+	<p:documentation xmlns="http://www.w3.org/1999/xhtml">
+		<p px:role="desc">Return an outline (ol element) from an (x)html page</p>
+	</p:documentation>
+	
+	<p:input port="source" sequence="true">
+		<p:documentation xmlns="http://www.w3.org/1999/xhtml">
+			<h2 px:role="name">Input (X)HTML stream</h2>
+			<p px:role="desc">The (X)HTML document from which the outline must be extracted</p>
+		</p:documentation>
+	</p:input>
+
+	<p:output port="result" sequence="true">
+		<p:documentation xmlns="http://www.w3.org/1999/xhtml">
+			<h2 px:role="name">Outline</h2>
+			<p px:role="desc">This steps output the outline of the html as a hierarchy of ordered lists</p>
+		</p:documentation>
+	</p:output>
+
+    <p:option name="file-uri" select="''" />
+
+	<p:documentation>Creating the outline</p:documentation>
+    <p:xslt>
+        <p:input port="stylesheet">
+            <p:document href="../xslt/html5-outliner.xsl"/>
+        </p:input>
+        <p:input port="parameters">
+            <p:empty/>
+        </p:input>
+    </p:xslt>
+    
+    <p:string-replace match="//@href">
+            <p:with-option name="replace" select="concat('concat(&quot;',$file-uri,'&quot;,.)')"/>
+    </p:string-replace>
+    
+
+</p:declare-step>

--- a/modules/common/html-utils/src/main/resources/xml/xslt/html5-outliner.xsl
+++ b/modules/common/html-utils/src/main/resources/xml/xslt/html5-outliner.xsl
@@ -5,18 +5,37 @@
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:tts="http://www.daisy.org/ns/pipeline/tts"
     exclude-result-prefixes="#all">
+    
 
     <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" omit-xml-declaration="no"/>
 
+    <!-- <xsl:strip-space elements="*"/> -->
+
+    <xsl:template match="/">
+        <xsl:message>Creating outline from html5</xsl:message>
+        <!-- For debugging
+        <xsl:variable name="document">
+            <xsl:copy-of select="*"/>
+        </xsl:variable>
+        <xsl:message select='$document'/> -->
+
+        <xsl:apply-templates/>
+    </xsl:template>
+
+    <!-- On the html tag found -->
     <xsl:template match="html">
+        <!-- Store a filtered version of the body in "filtered" 
+        This versions only contains the headers sections-->
         <xsl:variable name="filtered">
             <xsl:apply-templates select="body" mode="filtering"/>
         </xsl:variable>
+        <!-- Reconstruct an ordered list of filtered content -->
         <ol>
             <xsl:apply-templates select="$filtered/*"/>
         </ol>
     </xsl:template>
 
+    <!--  -->
     <xsl:template match="body|article|aside|nav|section">
         <xsl:variable name="id" select="@id"/>
         <xsl:variable name="heading" select="(h1|h2|h3|h4|h5|h6|hgroup)[1]" as="element()?"/>
@@ -25,13 +44,14 @@
             <xsl:copy-of select="* except $heading"/>
         </xsl:variable>
         <xsl:variable name="children" select="$children-doc/*" as="element()*"/>
-        <!--        <xsl:message select="concat('section: ',name())"/>-->
+        <!-- <xsl:message select="concat('section: ',name())"/> -->
         <xsl:choose>
+            <!-- When there are no children or the first children -->
             <xsl:when
                 test="empty($children) or $children[1][f:is-heading(.) and f:rank(.) >= f:rank($heading)]">
-                <!--                <xsl:message select="concat('heading only: ',$heading)"/>-->
+                <!-- <xsl:message select="concat('heading only: ',$heading)"/> -->
                 <li>
-                    <xsl:if test="empty($heading)">
+                    <xsl:if test="empty($heading) or not($heading/descendant-or-self::text())">
                         <xsl:attribute name="data-generated" select="'true'"/>
                     </xsl:if>
                     <a href="#{$id}">
@@ -44,12 +64,16 @@
         </xsl:choose>
         <xsl:for-each-group select="$children"
             group-starting-with="*[f:is-heading(.) and f:rank(.) >= f:rank($heading) and not(f:rank(preceding-sibling::*[1]) > f:rank(.))]">
+            <!-- <xsl:message select="$children" /> -->
             <xsl:choose>
                 <xsl:when
                     test="position()=1 and not(f:is-heading(.) and f:rank(.) ge f:rank($heading))">
-                    <!--                    <xsl:message select="concat('heading and subsections: ',$heading)"/>-->
+                    <!-- <xsl:message select="concat('heading and subsections: ',$heading, ' ', normalize-space($heading-content))"/> -->
+                    <!-- https://github.com/daisy/pipeline-tasks/issues/125 :
+                        an empty heading leads to an empty entry after the nav-fixer process, which leads to an invalid epub according to epubcheck.
+                        The corresponding entries are now also marked as "data-generated" to be identified by the nav-fixer as removable -->
                     <li>
-                        <xsl:if test="empty($heading)">
+                        <xsl:if test="empty($heading) or not($heading/descendant-or-self::text())">
                             <xsl:attribute name="data-generated" select="'true'"/>
                         </xsl:if>
                         <a href="#{$id}">
@@ -80,7 +104,7 @@
             <xsl:copy-of select="$elems[position()>1]"/>
         </xsl:variable>
         <xsl:variable name="children" select="$children-doc/*" as="element()*"/>
-        <!--        <xsl:message select="concat('implicit section ',$elems[1])"/>-->
+        <!-- <xsl:message select="concat('implicit section ',$elems[1])"/> -->
         <li>
             <xsl:if test="$elems[1]/empty(self::h1|self::h2|self::h3|self::h4|self::h5|self::h6|self::hgroup)">
                 <xsl:attribute name="data-generated" select="'true'"/>
@@ -88,6 +112,7 @@
             <a href="#{$elems[1]/@id}">
                 <xsl:copy-of select="f:heading-content($elems[1],())"/>
             </a>
+            <!-- Check if a real children exists (children with text node) -->
             <xsl:if test="$children">
                 <ol>
                     <xsl:call-template name="subsections">
@@ -97,12 +122,14 @@
             </xsl:if>
         </li>
     </xsl:template>
+
+    <!-- -->
     <xsl:template name="subsections">
         <xsl:param name="elems" as="element()*"/>
-        <!--        <xsl:message select="concat('subsections: ',string-join($elems/name(),' '))"/>-->
+        <!-- <xsl:message select="concat('subsections: ',string-join($elems/name(),' '))"/> -->
 
         <xsl:for-each-group select="$elems" group-adjacent="f:is-heading(.)">
-            <!--            <xsl:message select="concat('group: ',string-join(current-group()/name(),' '))"/>-->
+            <!-- <xsl:message select="concat('group: ',string-join(current-group()/name(),' '))"/> -->
             <xsl:choose>
                 <xsl:when test="f:is-heading(.)">
                     <xsl:for-each-group select="current-group()"
@@ -120,29 +147,43 @@
 
     </xsl:template>
 
+    <!-- On body|article|aside|nav|section matched tags in filtering context, 
+        construct a "filtered copy" of the tag and its attributes and content -->
     <xsl:template match="body|article|aside|nav|section" mode="filtering">
         <xsl:copy>
+            <!-- Copy the attributes -->
             <xsl:copy-of select="@*"/>
             <xsl:apply-templates select="*" mode="filtering"/>
         </xsl:copy>
     </xsl:template>
+
+
+    <!-- On h1|h2|h3|h4|h5|h6|hgroup matched tags in filtering context, 
+        construct a copy of node with attributes (and including previous TTS attributes) and content -->
     <xsl:template match="h1|h2|h3|h4|h5|h6|hgroup" mode="filtering">
         <xsl:copy>
             <!-- TODO: try to not "depend" on the TTS namespace here -->
             <xsl:copy-of select="@*|ancestor-or-self::*/@tts:*|node()"/>
         </xsl:copy>
     </xsl:template>
+    <!-- on blockquote|details|fieldset|figure|td in filtering mode, 
+        do nothing -->
     <xsl:template match="blockquote|details|fieldset|figure|td" mode="filtering"/>
+
+    <!-- on every not previously matched elements in filtering mode, 
+        Search and apply next template in filtering mode -->
     <xsl:template match="*" mode="filtering">
         <xsl:apply-templates select="*" mode="filtering"/>
     </xsl:template>
 
+    <!-- Check if node is a header -->
     <xsl:function name="f:is-heading" as="xs:boolean">
         <xsl:param name="node" as="element()"/>
         <xsl:sequence
             select="boolean($node[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6 or self::hgroup])"
         />
     </xsl:function>
+    <!-- -->
     <xsl:function name="f:rank" as="xs:integer">
         <xsl:param name="node" as="element()?"/>
         <xsl:choose>
@@ -158,12 +199,14 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:function>
+    
+    <!-- -->
     <xsl:function name="f:heading-content" as="item()*">
         <xsl:param name="node" as="element()?"/>
         <xsl:param name="parent" as="element()?"/>
         <xsl:choose>
             <xsl:when
-                test="$node[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]">
+                test="$node[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]/descendant-or-self::text()">
                 <xsl:apply-templates select="$node/(*|text())" mode="heading-content"/>
             </xsl:when>
             <xsl:when test="$node[self::hgroup]">
@@ -188,12 +231,16 @@
         </xsl:choose>
     </xsl:function>
 
+    <!-- On anchor matched in heading content context, 
+        Create a span with the copy of @class|@dir|@lang|@title attributes and with its content -->
     <xsl:template match="a" mode="heading-content">
         <span>
             <xsl:copy-of select="@class|@dir|@lang|@title"/>
             <xsl:apply-templates mode="heading-content"/>
         </span>
     </xsl:template>
+    
+    <!-- -->
     <xsl:template match="node() | @*" mode="heading-content">
         <xsl:copy>
             <xsl:apply-templates select="node() | @*" mode="heading-content"/>

--- a/modules/common/html-utils/src/test/xprocspec/test_html-outline.xprocspec
+++ b/modules/common/html-utils/src/test/xprocspec/test_html-outline.xprocspec
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.daisy.org/ns/xprocspec"
+               xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
+               script="../../main/resources/xml/xproc/html-outline.xpl">
+	
+	<x:scenario label="simple outline generation with empty title test">
+		<x:call step="px:html-outline">
+			<x:input port="source">
+				<x:document type="inline">
+					<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr">
+						<head><meta charset="UTF-8" /><title></title></head>
+						<body xmlns:epub="http://www.idpf.org/2007/ops" id="d862273e7-0" epub:type="frontmatter">
+							<section id="d861827e19">
+								<h1 id="d862273e9-0" epub:type="title"><span class="ftit"></span></h1>
+								<p><span class="auteur"><span class="pc">LOREM IPSUM</span> <span class="pc">LOREM IPSUM</span></span></p>
+						        <aside id="d862273e18-0" epub:type="annotation">Lorem ipsum dolor sit amet</aside>
+						    </section>
+						    <section id="d861827e29"><p>Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit.</p>
+						        <aside id="d862273e51-0" epub:type="annotation">Lorem ipsum</aside>
+						    </section>
+						    <section id="d861827e87">
+						    	<h1 id="d862273e78-0"><em>Table des matières</em></h1>
+						    	<p>Lorem ipsum dolor sit amet</p>
+						    </section>
+						    </body>
+						</html>
+				</x:document>
+			</x:input>
+		</x:call>
+		<x:context label="result-context">
+			<x:document type="port" port="result"/>
+		</x:context>
+		<x:expect label="result" type="compare">
+			<x:document type="inline">
+				<ol xmlns="http://www.w3.org/1999/xhtml">
+				   <li data-generated="true">
+				      <a href="#d862273e7-0">Untitled document</a>
+				      <ol>
+				         <li data-generated="true">
+				            <a href="#d861827e19">Untitled section</a>
+				            <ol>
+				               <li data-generated="true">
+				                  <a href="#d862273e18-0">Sidebar</a>
+				               </li>
+				            </ol>
+				         </li>
+				         <li data-generated="true">
+				            <a href="#d861827e29">Untitled section</a>
+				            <ol>
+				               <li data-generated="true">
+				                  <a href="#d862273e51-0">Sidebar</a>
+				               </li>
+				            </ol>
+				         </li>
+				         <li>
+				            <a href="#d861827e87">
+				               <em xmlns:epub="http://www.idpf.org/2007/ops">Table des matières</em>
+				            </a>
+				         </li>
+				      </ol>
+				   </li>
+				</ol>
+			</x:document>
+		</x:expect>
+	</x:scenario>
+
+	<x:scenario label="Outline with file reference anchor">
+		<x:call step="px:html-outline">
+			<x:option name="file-uri" select="'foo.xhtml'"/>
+			<x:input port="source">
+				<x:document type="inline">
+					<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr">
+						<head><meta charset="UTF-8" /><title></title></head>
+						<body xmlns:epub="http://www.idpf.org/2007/ops" id="d862273e7-0" epub:type="frontmatter">
+							<section id="d861827e19">
+								<h1 id="d862273e9-0" epub:type="title"><span class="ftit"></span></h1>
+								<p><span class="auteur"><span class="pc">LOREM IPSUM</span> <span class="pc">LOREM IPSUM</span></span></p>
+						        <aside id="d862273e18-0" epub:type="annotation">Lorem ipsum dolor sit amet</aside>
+						    </section>
+						    <section id="d861827e29"><p>Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit.</p>
+						        <aside id="d862273e51-0" epub:type="annotation">Lorem ipsum</aside>
+						    </section>
+						    <section id="d861827e87">
+						    	<h1 id="d862273e78-0"><em>Table des matières</em></h1>
+						    	<p>Lorem ipsum dolor sit amet</p>
+						    </section>
+						    </body>
+						</html>
+				</x:document>
+			</x:input>
+		</x:call>
+		<x:context label="result-context">
+			<x:document type="port" port="result"/>
+		</x:context>
+		<x:expect label="result" type="compare">
+			<x:document type="inline">
+				<ol xmlns="http://www.w3.org/1999/xhtml">
+				   <li data-generated="true">
+				      <a href="foo.xhtml#d862273e7-0">Untitled document</a>
+				      <ol>
+				         <li data-generated="true">
+				            <a href="foo.xhtml#d861827e19">Untitled section</a>
+				            <ol>
+				               <li data-generated="true">
+				                  <a href="foo.xhtml#d862273e18-0">Sidebar</a>
+				               </li>
+				            </ol>
+				         </li>
+				         <li data-generated="true">
+				            <a href="foo.xhtml#d861827e29">Untitled section</a>
+				            <ol>
+				               <li data-generated="true">
+				                  <a href="foo.xhtml#d862273e51-0">Sidebar</a>
+				               </li>
+				            </ol>
+				         </li>
+				         <li>
+				            <a href="foo.xhtml#d861827e87">
+				               <em xmlns:epub="http://www.idpf.org/2007/ops">Table des matières</em>
+				            </a>
+				         </li>
+				      </ol>
+				   </li>
+				</ol>
+			</x:document>
+		</x:expect>
+	</x:scenario>
+	
+</x:description>

--- a/modules/common/html-utils/src/test/xspec/html5-outliner.xspec
+++ b/modules/common/html-utils/src/test/xspec/html5-outliner.xspec
@@ -1103,4 +1103,54 @@
 		</x:expect>
 	</x:scenario>
 	
+	<x:scenario label="complex 8 - handle empty titles">
+		<x:context>
+			<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr">
+				<head><meta charset="UTF-8" /><title></title></head>
+				<body xmlns:epub="http://www.idpf.org/2007/ops" id="d862273e7-0" epub:type="frontmatter">
+					<section id="d861827e19">
+						<h1 id="d862273e9-0" epub:type="title"><span class="ftit"></span></h1>
+						<p><span class="auteur"><span class="pc">LOREM IPSUM</span> <span class="pc">LOREM IPSUM</span></span></p><aside id="d862273e18-0" epub:type="annotation">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</aside>
+				        </section>
+				        <section id="d861827e29"><p>Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.</p><aside id="d862273e51-0" epub:type="annotation">Image non fournie par l éditeur.</aside>
+				        </section>
+				        <section id="d861827e87">
+				        	<h1 id="d862273e78-0"><em>Table des matières</em></h1>
+				        	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua</p>
+				        </section>
+				    </body>
+				</html>
+		</x:context>
+		<x:expect label="outline">
+			<ol xmlns="http://www.w3.org/1999/xhtml">
+			   <li data-generated="true">
+			      <a href="#d862273e7-0">Untitled document</a>
+			      <ol>
+			         <li data-generated="true">
+			            <a href="#d861827e19">Untitled section</a>
+			            <ol>
+			               <li data-generated="true">
+			                  <a href="#d862273e18-0">Sidebar</a>
+			               </li>
+			            </ol>
+			         </li>
+			         <li data-generated="true">
+			            <a href="#d861827e29">Untitled section</a>
+			            <ol>
+			               <li data-generated="true">
+			                  <a href="#d862273e51-0">Sidebar</a>
+			               </li>
+			            </ol>
+			         </li>
+			         <li>
+			            <a href="#d861827e87">
+			               <em xmlns:epub="http://www.idpf.org/2007/ops">Table des matières</em>
+			            </a>
+			         </li>
+			      </ol>
+			   </li>
+			</ol>
+		</x:expect>
+	</x:scenario>
+	
 </x:description>

--- a/modules/common/mediatype-utils/src/main/resources/xml/maps/ext-to-mediatype.xml
+++ b/modules/common/mediatype-utils/src/main/resources/xml/maps/ext-to-mediatype.xml
@@ -13,7 +13,9 @@
     <entry key="xquery"    value="application/xquery+xml"/>
     <entry key="otf"       value="application/x-font-opentype"/>
     <entry key="ttf"       value="application/x-font-ttf"/>
+    <entry key="sfnt"      value="application/font-sfnt"/>
     <entry key="woff"      value="application/font-woff"/>
+    <entry key="woff2"     value="font/woff2"/>
     <entry key="eot"       value="application/vnd.ms-fontobject"/>
     <entry key="wav"       value="audio/x-wav"/>
     <entry key="opf"       value="application/oebps-package+xml"/>

--- a/modules/scripts-utils/epub3-nav-utils/src/main/resources/xml/xproc/epub3-nav-create-toc.xpl
+++ b/modules/scripts-utils/epub3-nav-utils/src/main/resources/xml/xproc/epub3-nav-create-toc.xpl
@@ -19,28 +19,26 @@
     <!-- integer -->
 
     <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
+    <p:import href="http://www.daisy.org/pipeline/modules/html-utils/library.xpl"/>
 
+    
+    <!-- create an ordered list (ol) from an xhtml document -->
     <p:for-each name="tocs">
         <p:output port="result" sequence="true"/>
         <p:variable name="base-uri" select="p:base-uri(/*)"/>
         <p:variable name="base-ref" select="if (starts-with($base-uri,$base-dir)) 
                     then substring-after($base-uri,$base-dir) 
                     else $base-uri"/>
-        <p:xslt>
-            <p:input port="stylesheet">
-                <p:document href="http://www.daisy.org/pipeline/modules/html-utils/html5-outliner.xsl"/>
-            </p:input>
-            <p:input port="parameters">
-                <p:empty/>
-            </p:input>
-        </p:xslt>
-        <p:string-replace match="//@href">
-            <p:with-option name="replace" select="concat('concat(&quot;',$base-ref,'&quot;,.)')"/>
-        </p:string-replace>
+        
+        <px:html-outline>
+            <p:with-option name="file-uri" select="$base-ref"/>
+        </px:html-outline>
+        
         <p:filter select="/h:ol/h:li"/>
     </p:for-each>
 
     <p:insert match="/h:nav/h:ol" position="first-child">
+        <!-- Prepare the table of content -->
         <p:input port="source">
             <p:inline exclude-inline-prefixes="#all">
                 <nav epub:type="toc" xmlns="http://www.w3.org/1999/xhtml">
@@ -49,6 +47,7 @@
                 </nav>
             </p:inline>
         </p:input>
+        <!-- Insert the result of previous step in the inlined "ol" -->
         <p:input port="insertion">
             <p:pipe port="result" step="tocs"/>
         </p:input>
@@ -60,8 +59,11 @@
             <p:pipe port="result" step="toc-string"/>
         </p:input>
     </p:replace>
+
+    <!-- unwrap the tocs titles subnodes (replace by their children) -->
     <p:unwrap match="//h:nav[@epub:type='toc']/h:h1/*"/>
 
+    <!-- Navigation correction -->
     <p:xslt>
         <p:input port="stylesheet">
             <p:document href="../xslt/nav-fixer.xsl"/>

--- a/modules/scripts-utils/epub3-nav-utils/src/main/resources/xml/xslt/nav-fixer.xsl
+++ b/modules/scripts-utils/epub3-nav-utils/src/main/resources/xml/xslt/nav-fixer.xsl
@@ -6,15 +6,39 @@
   exclude-result-prefixes="#all" version="2.0">
 
   <xsl:output method="xhtml" indent="yes"/>
+
   
   <xsl:param name="untitled" as="xs:string" select="'unwrap'"/>
+
+  <xsl:strip-space elements="ol li"/>
+
+  <xsl:template match="/">
+    <xsl:message>Fixing navigation (toc.xhtml via nav-fixer.xsl)</xsl:message>
+    <!-- DEBUGGING : retrieve the document structure -->
+    <!--<xsl:variable name="document">
+            <xsl:copy-of select="*"/>
+    </xsl:variable>
+    <xsl:message select='$document'/>-->
+
+    <!-- Pass 1 : unwrap -->
+    <xsl:variable name="temp">
+      <xsl:apply-templates />
+    </xsl:variable>
+
+    <!-- pass 2 : remove elements with no remaining text -->
+    <xsl:apply-templates mode="clean" select="$temp"/>
+  </xsl:template>
 
   <!--Unwraps all the "Untitled" top-level children of the Navigation Document-->
   
   <xsl:template match="li[@data-generated='true']">
     <xsl:choose>
       <xsl:when test="$untitled='unwrap'">
-        <xsl:apply-templates select="ol/*"/>
+        <!-- In unwrap mode, if a li with data generated attribute is found, 
+          jump to the next ol subnodes. 
+          (Note : ginving the structure, it will only copies the next sub li with no "data-generated" attribute) -->
+        <!-- The template should apply on OL that posess li child without @daa-generated attributes -->
+        <xsl:apply-templates select="ol/*" />
       </xsl:when>
       <xsl:when test="$untitled='hide'">
         <li hidden="true">
@@ -30,11 +54,20 @@
     </xsl:choose>
   </xsl:template>
   
+  <!-- For all nodes or attributes not previously matched -->
   <xsl:template match="node() | @*">
     <xsl:copy>
       <xsl:apply-templates select="node() | @*"/>
     </xsl:copy>
   </xsl:template>
-    
+
+
+  <!--remove elements with no text-->
+  <xsl:template mode="clean" match="node()[descendant::text() != ''] | @*">
+    <xsl:copy>
+      <xsl:apply-templates mode="clean" select="node() | @*"/>
+    </xsl:copy>
+  </xsl:template>
+  
 
 </xsl:stylesheet>

--- a/modules/scripts-utils/epub3-nav-utils/src/test/xspec/nav-fixer.xspec
+++ b/modules/scripts-utils/epub3-nav-utils/src/test/xspec/nav-fixer.xspec
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns="http://www.w3.org/1999/xhtml" 
+	xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:epub="http://www.idpf.org/2007/ops" 
+    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    stylesheet="../../main/resources/xml/xslt/nav-fixer.xsl">
+
+    <x:scenario label="pipeline-tasks/issues/125 - empty navigation elements filtered after toc creation process">
+    	<!-- Example of structure produced by epub3-nav-create-toc.xpl before nav-fixer.xsl -->
+    	<x:context>
+		   <nav epub:type="toc">
+			    <h1>Table of contents</h1>
+			    <ol>
+					<li data-generated="true">
+				      <a href="#d862273e7-0">Untitled document</a>
+				      <ol>
+				         <li data-generated="true">
+				            <a href="#d861827e19">Untitled section</a>
+				            <ol>
+				               <li data-generated="true">
+				                  <a href="#d862273e18-0">Sidebar</a>
+				               </li>
+				            </ol>
+				         </li>
+				         <li data-generated="true">
+				            <a href="#d861827e29">Untitled section</a>
+				            <ol>
+				               <li data-generated="true">
+				                  <a href="#d862273e51-0">Sidebar</a>
+				               </li>
+				            </ol>
+				         </li>
+				         <li>
+				            <a href="#d861827e87">
+				               <em>Lorem Ipsum</em>
+				            </a>
+				         </li>
+				      </ol>
+				   </li>
+			    </ol>
+			</nav>
+    	</x:context>
+    	<x:expect label="Non auto-generated titled">
+			<nav epub:type="toc">
+			   <h1>Table of contents</h1>
+			   <ol>
+			      <li><a href="#d861827e87"><em>Lorem Ipsum</em></a></li>
+			   </ol>
+			</nav>
+    	</x:expect>
+    	
+
+    </x:scenario>
+
+
+</x:description>

--- a/modules/scripts-utils/epub3-pub-utils/src/main/resources/xml/xproc/create-metadata.merge.xsl
+++ b/modules/scripts-utils/epub3-pub-utils/src/main/resources/xml/xproc/create-metadata.merge.xsl
@@ -120,6 +120,12 @@
                     an undeclared vocab.</xsl:message>
             </xsl:when>
             <xsl:when
+                test="$property/@prefix='' and $property/@name=('display-seq','meta-auth')">
+                <xsl:message>[WARNING] The deprecated property '<xsl:value-of select="@property"
+                    />' was found.</xsl:message>
+                    <xsl:next-match/>
+            </xsl:when>
+            <xsl:when
                 test="$property/@prefix='' and not($property/@name=('alternate-script','display-seq',
                 'file-as','group-position','identifier-type','meta-auth','role','title-type'))">
                 <xsl:message>[WARNING] Discarding unknown property '<xsl:value-of select="@property"
@@ -139,9 +145,17 @@
                 <xsl:message>[WARNING] Discarding link with no @href or @rel
                     attributes.</xsl:message>
             </xsl:when>
+            <!-- EPUB3.2: values marc21xml-record, mods-record, onix-record, and xmp-signature of @rel are deprecated and should be replaced by 'record'-->
+            <xsl:when
+                test="$rel/@prefix='' and $rel/@name=('marc21xml-record',
+                'mods-record','onix-record','xml-signature xmp-record')">
+                <xsl:message>[WARNING] Found link with deprecated @rel value '<xsl:value-of
+                        select="@rel"/>'. This value should be replaced by 'record' with a corresponding 'media-type' attribute.</xsl:message>
+                    <xsl:next-match/>
+            </xsl:when>
             <xsl:when
                 test="$rel/@prefix='' and not($rel/@name=('marc21xml-record',
-                'mods-record','onix-record','xml-signature xmp-record'))">
+                'mods-record','onix-record','xml-signature xmp-record','record','acquire','alternate'))">
                 <xsl:message>[WARNING] Discarding link with unknown @rel value '<xsl:value-of
                         select="@rel"/>'.</xsl:message>
             </xsl:when>

--- a/modules/scripts-utils/epub3-pub-utils/src/main/resources/xml/xproc/create-package-doc.handler-fileset-to-bindings.xsl
+++ b/modules/scripts-utils/epub3-pub-utils/src/main/resources/xml/xproc/create-package-doc.handler-fileset-to-bindings.xsl
@@ -2,8 +2,9 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" exclude-result-prefixes="#all">
     <xsl:output indent="yes"/>
     <xsl:template match="/*">
-        <bindings>
+        <bindings> <!-- TODO : bindings is deprecated from 3.2 and may be removed in futur specs -->
             <xsl:for-each select="*">
+                <xsl:message>[WARNING] Bindings are deprecated and should not be used anymore. Please use HTML <object/> content fallback instead for <xsl:value-of select="@media-type"/>.</xsl:message>
                 <mediaType handler="{@handler}" media-type="{@media-type}"/>
             </xsl:for-each>
         </bindings>

--- a/modules/scripts-utils/metadata-utils/src/main/resources/xml/zedai-to-metadata.xsl
+++ b/modules/scripts-utils/metadata-utils/src/main/resources/xml/zedai-to-metadata.xsl
@@ -93,13 +93,13 @@
       select="ancestor::z:head//z:meta[@property='z3998:meta-record-type' and @about=$this/@resource][1]/@content"/>
     <xsl:choose>
       <xsl:when test="$record-type='z3998:mods'">
-        <link rel="mods-record" href="{@resource}"/>
+        <link rel="record" href="{@resource}" media-type="application/mods+xml"/>
       </xsl:when>
       <xsl:when test="$record-type='z3998:onix-books'">
-        <link rel="onix-record" href="{@resource}"/>
+        <link rel="record" href="{@resource}" media-type="application/xml" properties="onix"/>
       </xsl:when>
       <xsl:when test="$record-type='z3998:marc21-xml'">
-        <link rel="marc21xml-record" href="{@resource}"/>
+        <link rel="record" href="{@resource}" media-type="application/marcxml+xml"/>
       </xsl:when>
       <xsl:when test="$record-type=('z3998:dcterms-rdf','z3998:dctersm-rdfa')">
         <!--TODO translate external DCTERMS records ?-->
@@ -176,6 +176,7 @@
     </xsl:if>
   </xsl:template>
 
+  <!-- in case of DTBooks, the doctitle tag is converted here as a dc:title -->
   <xsl:template match="z:*[f:hasPropOrRole(.,('title','covertitle','halftitle'))]" mode="title">
     <xsl:call-template name="create-title"/>
   </xsl:template>
@@ -185,11 +186,17 @@
   </xsl:template>
 
   <xsl:template name="create-title">
-    <dc:title id="{generate-id()}">
-      <xsl:copy-of select="@dir"/>
-      <xsl:copy-of select="@xml:lang"/>
-      <xsl:value-of select="if (string(.)) then normalize-space(string(.)) else @content"/>
-    </dc:title>
+    <!-- FIX - http://www.github.com/daisy/pipeline-tasks#125 : 
+      empty doctitle could lead to empty tag with role title, 
+        wich would lead to the creation of an empty dc:title tag
+        thus making the epub invalid for epubcheck. -->
+    <xsl:if test=".//text()[not(self::text()[not(normalize-space())])] != '' or @content">
+      <dc:title id="{generate-id()}">
+        <xsl:copy-of select="@dir"/>
+        <xsl:copy-of select="@xml:lang"/>
+        <xsl:value-of select="if (string(.)) then normalize-space(string(.)) else @content"/>
+      </dc:title>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template match="text()" mode="#all"/>


### PR DESCRIPTION
Changes made to prepare the pipeline for the new [ePub 3.2 specification](https://w3c.github.io/publ-epub-revision/epub32/spec/epub-spec.html).

- Modified the mediatype mapping for the new media types compliant with epub 3.2
- Modified the metadata generation from zedai metadata process to complies with epub 3.2 specification.
- The epub3 metadata merging process raises a warning on metadata that are now deprecated with epub 3.2 specification
- The bindings generation process raises a warning, as this mechanism is deprecated in epub 3.2 specification and should be replaced by the standard HTML object fallback
- Fixed the generation of an empty dc:title tag when an empty doctitle tag was found in dtbooks.
- Fixed the generation of empty entries in the toc document of an epub when data-generated section or empty titles are found.
- New html-outline xproc step to encapsulate html5-outliner.xsl (the xsl is also removed from catalog)
- New corresponding xprocstep tests
- The toc creation step has been updated to use the new px:html-outline step
