### PR TITLE
Some changes/improvements to the braille scripts

### DIFF
--- a/html-to-pef/src/main/resources/xml/xproc/html-to-pef.store.xpl
+++ b/html-to-pef/src/main/resources/xml/xproc/html-to-pef.store.xpl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step type="px:html-to-pef.store" version="1.0"
+                xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
+                exclude-inline-prefixes="#all"
+                name="main">
+    
+    <p:input port="html" primary="false"/>
+    <p:input port="obfl" primary="false">
+        <p:empty/>
+    </p:input>
+    <p:input port="pef" primary="true">
+        <p:empty/>
+    </p:input>
+    
+    <p:option name="pef-output-dir" select="''"/>
+    <p:option name="brf-output-dir" select="''"/>
+    <p:option name="preview-output-dir" select="''"/>
+    <p:option name="obfl-output-dir" select="''"/>
+    
+    <p:option name="include-preview" select="'false'"/>
+    <p:option name="include-brf" select="'false'"/>
+    <p:option name="ascii-file-format" select="''"/>
+    <p:option name="ascii-table" select="''"/>
+    
+    <p:import href="http://www.daisy.org/pipeline/modules/braille/xml-to-pef/library.xpl"/>
+    
+    <px:xml-to-pef.store>
+        <p:input port="obfl">
+            <p:pipe step="main" port="obfl"/>
+        </p:input>
+        <p:with-option name="name" select="replace(p:base-uri(/),'^.*/([^/]*)\.[^/\.]*$','$1')">
+            <p:pipe step="main" port="html"/>
+        </p:with-option>
+        <p:with-option name="include-brf" select="$include-brf"/>
+        <p:with-option name="include-preview" select="$include-preview"/>
+        <p:with-option name="ascii-file-format" select="$ascii-file-format"/>
+        <p:with-option name="ascii-table" select="$ascii-table"/>
+        <p:with-option name="pef-output-dir" select="$pef-output-dir"/>
+        <p:with-option name="brf-output-dir" select="$brf-output-dir"/>
+        <p:with-option name="preview-output-dir" select="$preview-output-dir"/>
+        <p:with-option name="obfl-output-dir" select="$obfl-output-dir"/>
+    </px:xml-to-pef.store>
+    
+</p:declare-step>

--- a/modules/braille/xml-to-pef/src/main/resources/xml/xslt/generate-toc.xsl
+++ b/modules/braille/xml-to-pef/src/main/resources/xml/xslt/generate-toc.xsl
@@ -8,10 +8,10 @@
   
   <!-- stylesheet defaults to names used in HTML if no other grammar is detected -->
   
-  <xsl:param name="depth" as="xs:string"/>
+  <xsl:param name="toc-depth" as="xs:string"/>
   <xsl:param name="heading-names" select="''"/>
   
-  <xsl:variable name="_depth" as="xs:integer" select="if ($depth) then xs:integer($depth) else 6"/>
+  <xsl:variable name="_depth" as="xs:integer" select="if ($toc-depth) then xs:integer($toc-depth) else 6"/>
   
   <xsl:variable name="root-base-uri" as="xs:anyURI" select="base-uri(/*)"/>
   

--- a/modules/scripts/dtbook-to-pef/src/main/resources/xml/xproc/dtbook-to-pef.convert.xpl
+++ b/modules/scripts/dtbook-to-pef/src/main/resources/xml/xproc/dtbook-to-pef.convert.xpl
@@ -73,22 +73,16 @@
         <px:assert message="More than one DTBook found in fileset." test-count-max="1" error-code="PEZE00"/>
     </p:group>
     
-    <p:xslt px:message="Generating table of contents" px:progress=".01">
-        <p:input port="stylesheet">
-            <p:document href="http://www.daisy.org/pipeline/modules/braille/xml-to-pef/generate-toc.xsl"/>
-        </p:input>
-        <p:with-param name="depth" select="/*/*[@name='toc-depth']/@value">
-            <p:pipe step="parameters" port="result"/>
-        </p:with-param>
-    </p:xslt>
-    
-    <p:group px:message="Applying style sheets" px:progress=".07">
+    <p:group px:message="Applying style sheets" px:progress=".08">
         <p:variable name="first-css-stylesheet"
                     select="tokenize($stylesheet,'\s+')[matches(.,'\.s?css$')][1]"/>
         <p:variable name="first-css-stylesheet-index"
                     select="(index-of(tokenize($stylesheet,'\s+')[not(.='')], $first-css-stylesheet),10000)[1]"/>
         <p:variable name="stylesheets-to-be-inlined"
                     select="string-join((
+                              if (tokenize($stylesheet,'\s+') = 'http://www.daisy.org/pipeline/modules/braille/xml-to-pef/generate-toc.xsl')
+                                then ()
+                                else 'http://www.daisy.org/pipeline/modules/braille/xml-to-pef/generate-toc.xsl',
                               (tokenize($stylesheet,'\s+')[not(.='')])[position()&lt;$first-css-stylesheet-index],
                               $default-stylesheet,
                               resolve-uri('../../css/default.scss'),

--- a/modules/scripts/dtbook-to-pef/src/main/resources/xml/xproc/dtbook-to-pef.convert.xpl
+++ b/modules/scripts/dtbook-to-pef/src/main/resources/xml/xproc/dtbook-to-pef.convert.xpl
@@ -47,7 +47,6 @@
     <p:import href="http://www.daisy.org/pipeline/modules/braille/common-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/braille/xml-to-pef/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/braille/pef-utils/library.xpl"/>
-    <p:import href="http://www.daisy.org/pipeline/modules/file-utils/library.xpl"/>
     <p:import href="http://www.daisy.org/pipeline/modules/fileset-utils/library.xpl"/>
     
     <!-- Ensure that there's exactly one c:param-set -->
@@ -107,6 +106,9 @@
                         <p:pipe step="dtbook" port="result"/>
                     </p:with-option>
                     <p:with-option name="temp-dir" select="$temp-dir"/>
+                    <p:input port="parameters">
+                        <p:pipe port="result" step="parameters"/>
+                    </p:input>
                 </px:transform>
             </p:viewport>
         </p:when>

--- a/modules/scripts/epub3-to-pef/src/main/resources/xml/xproc/epub3-to-pef.convert.xpl
+++ b/modules/scripts/epub3-to-pef/src/main/resources/xml/xproc/epub3-to-pef.convert.xpl
@@ -150,16 +150,7 @@
         </p:with-option>
     </p:add-attribute>
     
-    <p:xslt px:message="Generating table of contents" px:progress=".01">
-        <p:input port="stylesheet">
-            <p:document href="http://www.daisy.org/pipeline/modules/braille/xml-to-pef/generate-toc.xsl"/>
-        </p:input>
-        <p:with-param name="depth" select="/*/*[@name='toc-depth']/@value">
-            <p:pipe step="parameters" port="result"/>
-        </p:with-param>
-    </p:xslt>
-    
-    <p:group px:message="Inlining global CSS" px:progress=".10">
+    <p:group px:message="Inlining global CSS" px:progress=".11">
         <p:variable name="abs-stylesheet"
                     select="string-join(for $s in tokenize($stylesheet,'\s+')[not(.='')]
                                         return resolve-uri($s,$epub),' ')"/>
@@ -169,6 +160,9 @@
                     select="(index-of(tokenize($abs-stylesheet,'\s+')[not(.='')], $first-css-stylesheet),10000)[1]"/>
         <p:variable name="stylesheets-to-be-inlined"
                     select="string-join((
+                              if (tokenize($stylesheet,'\s+') = 'http://www.daisy.org/pipeline/modules/braille/xml-to-pef/generate-toc.xsl')
+                                then ()
+                                else 'http://www.daisy.org/pipeline/modules/braille/xml-to-pef/generate-toc.xsl',
                               (tokenize($abs-stylesheet,'\s+')[not(.='')])[position()&lt;$first-css-stylesheet-index],
                               $default-stylesheet,
                               resolve-uri('../../css/default.scss'),

--- a/modules/scripts/html-to-pef/src/main/resources/xml/xproc/html-to-pef.convert.xpl
+++ b/modules/scripts/html-to-pef/src/main/resources/xml/xproc/html-to-pef.convert.xpl
@@ -85,22 +85,16 @@
     <px:assert message="More than one XHTML documents found." test-count-max="1" error-code="PEZE00"/>
     <p:identity name="html"/>
     
-    <p:xslt px:message="Generating table of contents" px:progress=".01">
-        <p:input port="stylesheet">
-            <p:document href="http://www.daisy.org/pipeline/modules/braille/xml-to-pef/generate-toc.xsl"/>
-        </p:input>
-        <p:with-param name="depth" select="/*/*[@name='toc-depth']/@value">
-            <p:pipe step="parameters" port="result"/>
-        </p:with-param>
-    </p:xslt>
-    
-    <p:group px:message="Inlining CSS" px:progress=".10">
+    <p:group px:message="Inlining CSS" px:progress=".11">
         <p:variable name="first-css-stylesheet"
                     select="tokenize($stylesheet,'\s+')[matches(.,'\.s?css$')][1]"/>
         <p:variable name="first-css-stylesheet-index"
                     select="(index-of(tokenize($stylesheet,'\s+')[not(.='')], $first-css-stylesheet),10000)[1]"/>
         <p:variable name="stylesheets-to-be-inlined"
                     select="string-join((
+                              if (tokenize($stylesheet,'\s+') = 'http://www.daisy.org/pipeline/modules/braille/xml-to-pef/generate-toc.xsl')
+                                then ()
+                                else 'http://www.daisy.org/pipeline/modules/braille/xml-to-pef/generate-toc.xsl',
                               (tokenize($stylesheet,'\s+')[not(.='')])[position()&lt;$first-css-stylesheet-index],
                               $default-stylesheet,
                               resolve-uri('../../css/default.scss'),

--- a/modules/scripts/html-to-pef/src/main/resources/xml/xproc/html-to-pef.convert.xpl
+++ b/modules/scripts/html-to-pef/src/main/resources/xml/xproc/html-to-pef.convert.xpl
@@ -95,10 +95,16 @@
     </p:xslt>
     
     <p:group px:message="Inlining CSS" px:progress=".10">
-        <p:variable name="stylesheets-to-be-inlined" select="string-join((
-                                                               $default-stylesheet,
-                                                               resolve-uri('../../css/default.scss'),
-                                                               $stylesheet),' ')">
+        <p:variable name="first-css-stylesheet"
+                    select="tokenize($stylesheet,'\s+')[matches(.,'\.s?css$')][1]"/>
+        <p:variable name="first-css-stylesheet-index"
+                    select="(index-of(tokenize($stylesheet,'\s+')[not(.='')], $first-css-stylesheet),10000)[1]"/>
+        <p:variable name="stylesheets-to-be-inlined"
+                    select="string-join((
+                              (tokenize($stylesheet,'\s+')[not(.='')])[position()&lt;$first-css-stylesheet-index],
+                              $default-stylesheet,
+                              resolve-uri('../../css/default.scss'),
+                              (tokenize($stylesheet,'\s+')[not(.='')])[position()&gt;=$first-css-stylesheet-index]),' ')">
             <p:inline><_/></p:inline>
         </p:variable>
         <p:identity px:message="stylesheets: {$stylesheets-to-be-inlined}"/>

--- a/modules/scripts/html-to-pef/src/main/resources/xml/xproc/library.xpl
+++ b/modules/scripts/html-to-pef/src/main/resources/xml/xproc/library.xpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:library xmlns:p="http://www.w3.org/ns/xproc"
-    version="1.0">
+<p:library xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
 
     <p:import href="html-to-pef.convert.xpl"/>
+    <p:import href="html-to-pef.store.xpl"/>
 
 </p:library>

--- a/scripts/html-to-pef/src/main/resources/xml/xproc/html-to-pef.store.xpl
+++ b/scripts/html-to-pef/src/main/resources/xml/xproc/html-to-pef.store.xpl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step type="px:html-to-pef.store" version="1.0"
+                xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
+                exclude-inline-prefixes="#all"
+                name="main">
+    
+    <p:input port="html" primary="false"/>
+    <p:input port="obfl" primary="false">
+        <p:empty/>
+    </p:input>
+    <p:input port="pef" primary="true">
+        <p:empty/>
+    </p:input>
+    
+    <p:option name="pef-output-dir" select="''"/>
+    <p:option name="brf-output-dir" select="''"/>
+    <p:option name="preview-output-dir" select="''"/>
+    <p:option name="obfl-output-dir" select="''"/>
+    
+    <p:option name="include-preview" select="'false'"/>
+    <p:option name="include-brf" select="'false'"/>
+    <p:option name="ascii-file-format" select="''"/>
+    <p:option name="ascii-table" select="''"/>
+    
+    <p:import href="http://www.daisy.org/pipeline/modules/braille/xml-to-pef/library.xpl"/>
+    
+    <px:xml-to-pef.store>
+        <p:input port="obfl">
+            <p:pipe step="main" port="obfl"/>
+        </p:input>
+        <p:with-option name="name" select="replace(p:base-uri(/),'^.*/([^/]*)\.[^/\.]*$','$1')">
+            <p:pipe step="main" port="html"/>
+        </p:with-option>
+        <p:with-option name="include-brf" select="$include-brf"/>
+        <p:with-option name="include-preview" select="$include-preview"/>
+        <p:with-option name="ascii-file-format" select="$ascii-file-format"/>
+        <p:with-option name="ascii-table" select="$ascii-table"/>
+        <p:with-option name="pef-output-dir" select="$pef-output-dir"/>
+        <p:with-option name="brf-output-dir" select="$brf-output-dir"/>
+        <p:with-option name="preview-output-dir" select="$preview-output-dir"/>
+        <p:with-option name="obfl-output-dir" select="$obfl-output-dir"/>
+    </px:xml-to-pef.store>
+    
+</p:declare-step>


### PR DESCRIPTION
- make px:html-to-pef.convert work the same way as px:dtbook-to-pef.convert
- add px:html-to-pef.store
- xml-to-pef: make it possible to preprocess before generating toc
- Support XSLT style sheets in stylesheet option of html-to-pef
