### PR TITLE
fix <title> in ncc for DAISY3->DAISY 2.02

### DIFF
--- a/modules/scripts/daisy3-to-daisy202/src/main/resources/xml/internal/ncx-to-ncc.xsl
+++ b/modules/scripts/daisy3-to-daisy202/src/main/resources/xml/internal/ncx-to-ncc.xsl
@@ -18,7 +18,7 @@
         <html>
             <head>
                 <title>
-                    <xsl:value-of select="$metadata/meta[@name='dc:title']"/>
+			<xsl:value-of select="$metadata/*[local-name()='meta'][@name='dc:title']/@content"/>
                 </title>
                 <xsl:copy-of select="$metadata/*"/>
                 


### PR DESCRIPTION
<i>Correct the ncc.html to include title content (DAISY3 to DAISY2.02):</i>

The xml style sheet contains an error that results in the <title> in the ncc.html being blank. This patch corrects this.
I've changed the ncx-to-ncc.xsl file but it seems the build process does not rebuild the jar (/daisy-pipeline/system/felix/org.daisy.pipeline.modules.daisy3-to-daisy202-2.0.1.jar). (Perhaps this comes from the maven repo)  

I had to insert the file manually after the build.