### PR TITLE
Webui login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ bin/
 target/
 /build/
 /node-modules/
+*.iml
+.idea

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,14 @@ dist-docker-image : assembly/.compile-dependencies | .maven-init .group-eval
 .PHONY : dist-cli-deb
 dist-cli-deb : cli-$(cli/VERSION)-linux_386.deb
 
+.PHONY : dist-webui-zip
+dist-webui-zip : assembly/.compile-dependencies
+	# see webui README for instructions on how to make a signed package for distribution
+	cd webui && \
+	./activator -Dmvn.settings.localRepository="file:$(CURDIR)/$(MVN_WORKSPACE)" clean universal:packageBin | $(MVN_LOG)
+	mv webui/target/universal/*zip .
+
+
 .PHONY : dist-webui-deb
 dist-webui-deb : assembly/.compile-dependencies
 	# see webui README for instructions on how to make a signed package for distribution

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -83,7 +83,7 @@
       <dependency>
         <groupId>org.daisy.pipeline</groupId>
         <artifactId>framework-bom</artifactId>
-        <version>1.14.4</version>
+        <version>1.14.5-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -2765,7 +2765,7 @@
     <repository>
       <id>restlet-repo</id>
       <name>Public online Restlet repository</name>
-      <url>http://maven.restlet.org</url>
+      <url>https://maven.restlet.talend.com</url>
       <releases>
         <enabled>true</enabled>
       </releases>

--- a/clientlib/java/clientlib-java-httpclient/src/main/java/org/daisy/pipeline/client/http/Pipeline2HttpClient.java
+++ b/clientlib/java/clientlib-java-httpclient/src/main/java/org/daisy/pipeline/client/http/Pipeline2HttpClient.java
@@ -252,20 +252,8 @@ public class Pipeline2HttpClient {
 
 			url += "authid="+username + "&time="+time + "&nonce="+nonce;
 
-			String hash = "";
 			try {
-				hash = calculateRFC2104HMAC(url, secret);
-				String hashEscaped = "";
-				char c;
-				for (int i = 0; i < hash.length(); i++) {
-					// Base64 encoding uses + which we have to encode in URL parameters.
-					// Hoping this for loop is more efficient than the equivalent replace("\\+","%2B") regex.
-					c = hash.charAt(i);
-					if (c == '+') hashEscaped += "%2B";
-					else hashEscaped += c;
-				} 
-				url += "&sign="+hashEscaped;
-
+				url += "&sign=" + calculateRFC2104HMAC(url, secret);
 			} catch (SignatureException e) {
 				throw new Pipeline2Exception("Could not sign request.");
 			}
@@ -302,7 +290,7 @@ public class Pipeline2HttpClient {
             byte[] rawHmac = mac.doFinal(data.getBytes());
 
             // base64-encode the hmac
-            result = Base64.getEncoder().encode(rawHmac);
+            result = Base64.getUrlEncoder().withoutPadding().encode(rawHmac);
 
         } catch (Exception e) {
             throw new SignatureException("Failed to generate HMAC : " + e.getMessage());

--- a/framework/bom/pom.xml
+++ b/framework/bom/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.daisy.pipeline</groupId>
   <artifactId>framework-bom</artifactId>
-  <version>1.14.4</version>
+  <version>1.14.5-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>DAISY Pipeline 2 :: Framework BoM</name>
@@ -105,7 +105,7 @@
       <dependency>
         <groupId>org.daisy.pipeline</groupId>
         <artifactId>webservice</artifactId>
-        <version>2.4.1</version>
+        <version>2.4.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline</groupId>

--- a/framework/common-utils/pom.xml
+++ b/framework/common-utils/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.daisy.pipeline</groupId>
     <artifactId>framework-parent</artifactId>
-    <version>1.14.4</version>
+    <version>1.14.5-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
 
   <artifactId>common-utils</artifactId>
-  <version>5.1.1</version>
+  <version>5.1.2-SNAPSHOT</version>
 
   <packaging>bundle</packaging>
   <name>DAISY Pipeline 2 :: Common Utilities</name>

--- a/framework/parent/pom.xml
+++ b/framework/parent/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.daisy.pipeline</groupId>
   <artifactId>framework-parent</artifactId>
-  <version>1.14.4</version>
+  <version>1.14.5-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>DAISY Pipeline 2 :: Framework Parent POM</name>
@@ -110,7 +110,7 @@
       <dependency>
         <groupId>org.daisy.pipeline</groupId>
         <artifactId>framework-bom</artifactId>
-        <version>1.14.4</version>
+        <version>1.14.5-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -123,7 +123,7 @@
       <dependency>
         <groupId>org.daisy.pipeline</groupId>
         <artifactId>clientlib-java-jaxb</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.daisy.maven</groupId>
@@ -266,7 +266,7 @@
     <repository>
       <id>restlet-repo</id>
       <name>Public online Restlet repository</name>
-      <url>http://maven.restlet.org</url>
+      <url>https://maven.restlet.talend.com</url>
       <releases>
         <enabled>true</enabled>
       </releases>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.daisy.pipeline</groupId>
   <artifactId>framework-aggregator</artifactId>
-  <version>1.14.4</version>
+  <version>1.14.5-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>DAISY Pipeline 2 :: Framework Aggregator</name>

--- a/framework/utils/clientlib-java-jaxb/pom.xml
+++ b/framework/utils/clientlib-java-jaxb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.daisy.pipeline</groupId>
     <artifactId>framework-parent</artifactId>
-    <version>1.14.4-SNAPSHOT</version>
+    <version>1.14.5-SNAPSHOT</version>
     <relativePath>../../parent</relativePath>
   </parent>
   <groupId>org.daisy.pipeline</groupId>

--- a/framework/utils/clientlib-java-jaxb/src/main/java/org/daisy/pipeline/client/PipelineClient.java
+++ b/framework/utils/clientlib-java-jaxb/src/main/java/org/daisy/pipeline/client/PipelineClient.java
@@ -4,6 +4,7 @@ package org.daisy.pipeline.client;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
+import java.util.Base64;
 import java.util.Date;
 import java.util.Random;
 
@@ -19,8 +20,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 
 import com.google.common.base.Strings;
-
-import org.apache.commons.codec.binary.Base64;
 
 import org.daisy.pipeline.webservice.jaxb.base.Alive;
 import org.daisy.pipeline.webservice.jaxb.clients.Client;
@@ -184,8 +183,7 @@ public class PipelineClient {
 
                 @Override
                 public void filter(ClientRequestContext ctxt) throws IOException {
-                        String timestamp=new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
-                        .format(new Date());
+                        String timestamp=new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(new Date());
                         String nonce=new Integer(new Random().nextInt(1073741824)).toString();
                         nonce=Strings.padStart(nonce,30,'0');
                         
@@ -199,11 +197,10 @@ public class PipelineClient {
                                 Mac mac = Mac.getInstance("HmacSHA1");
                                 mac.init(key);
 
-
                                 byte[] bytes = mac.doFinal(builder.clone().build()
                                                 .toString().getBytes("UTF-8"));
 
-                                builder.queryParam("sign",Base64.encodeBase64String(bytes));
+                                builder.queryParam("sign", Base64.getUrlEncoder().withoutPadding().encodeToString(bytes));
                                 ctxt.setUri(builder.build());
                         } catch (Exception e) {
                                 logger.warn(e.getMessage());
@@ -211,7 +208,7 @@ public class PipelineClient {
                         }
 
 
-                        
+
 
                 }
                 

--- a/framework/webservice/pom.xml
+++ b/framework/webservice/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.daisy.pipeline</groupId>
     <artifactId>framework-parent</artifactId>
-    <version>1.14.4-SNAPSHOT</version>
+    <version>1.14.5-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
 

--- a/framework/webservice/src/main/java/org/daisy/pipeline/webservice/Authenticator.java
+++ b/framework/webservice/src/main/java/org/daisy/pipeline/webservice/Authenticator.java
@@ -6,14 +6,13 @@ import java.security.SignatureException;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Base64;
 import java.util.Date;
 import java.util.Random;
 import java.util.TimeZone;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-
-import org.apache.commons.codec.binary.Base64;
 
 import org.daisy.pipeline.clients.Client;
 import org.daisy.pipeline.clients.RequestLog;
@@ -35,7 +34,6 @@ public class Authenticator {
 	public boolean authenticate(Client client, String hash, String timestamp, String nonce, String URI, long maxRequestTime) {
 		// rules for hashing: use the whole URL string, minus the hash part (&sign=<some value>)
 		// important!  put the sign param last so we can easily strip it out
-
 		int idx = URI.indexOf("&sign=", 0);
 
 		if (idx > 1) {
@@ -157,10 +155,9 @@ public class Authenticator {
 			byte[] rawHmac = mac.doFinal(data.getBytes());
 
 			// base64-encode the hmac
-			result = Base64.encodeBase64String(rawHmac);
-
-			} catch (Exception e) {
-				throw new SignatureException("Failed to generate HMAC : " + e.getMessage());
+			result = Base64.getUrlEncoder().withoutPadding().encodeToString(rawHmac);
+		} catch (Exception e) {
+			throw new SignatureException("Failed to generate HMAC : " + e.getMessage());
 		}
 		return result;
 	}

--- a/libs/com.xmlcalabash/build.gradle
+++ b/libs/com.xmlcalabash/build.gradle
@@ -29,7 +29,7 @@ targetCompatibility = "1.7"
 repositories {
   // mavenLocal()
   mavenCentral()
-  maven { url "http://maven.restlet.org" }
+  maven { url "https://maven.restlet.talend.com" }
   maven { url "https://developer.marklogic.com/maven2" }
   maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 }
@@ -440,7 +440,7 @@ def mavenPom = {
   repositories {
     repository {
       id 'restlet'
-      url 'https://maven.restlet.org'
+      url 'https://maven.restlet.talend.com'
     }
   }
 }

--- a/modules/parent/pom.xml
+++ b/modules/parent/pom.xml
@@ -1024,7 +1024,7 @@
     <repository>
       <id>restlet-repo</id>
       <name>Public online Restlet repository</name>
-      <url>http://maven.restlet.org</url>
+      <url>https://maven.restlet.talend.com</url>
       <releases>
         <enabled>true</enabled>
       </releases>

--- a/settings.xml.in
+++ b/settings.xml.in
@@ -40,7 +40,7 @@
 				</repository>
 				<repository>
 					<id>restlet-repo</id>  <!-- defined in framework-parent -->
-					<url>http://maven.restlet.org</url>
+					<url>https://maven.restlet.talend.com</url>
 					<releases>
 						<enabled>true</enabled>
 					</releases>

--- a/utils/build-utils/pax-exam-helper/pom.xml
+++ b/utils/build-utils/pax-exam-helper/pom.xml
@@ -338,7 +338,7 @@
     <repository>
       <id>restlet-repo</id>
       <name>Public online Restlet repository</name>
-      <url>http://maven.restlet.org</url>
+      <url>https://maven.restlet.talend.com</url>
       <releases>
         <enabled>true</enabled>
       </releases>

--- a/utils/xproc-maven-plugin/xproc-engine-calabash/pom.xml
+++ b/utils/xproc-maven-plugin/xproc-engine-calabash/pom.xml
@@ -85,7 +85,7 @@
     <repository>
       <id>restlet-repo</id>
       <name>Public online Restlet repository</name>
-      <url>http://maven.restlet.org</url>
+      <url>https://maven.restlet.talend.com</url>
       <releases>
         <enabled>true</enabled>
       </releases>

--- a/webui/app/controllers/SystemStatus.java
+++ b/webui/app/controllers/SystemStatus.java
@@ -121,7 +121,7 @@ public class SystemStatus extends Controller {
 			attempt.lastAuthTime = new Date();
 			if (attempt.alive != null && authid != null && secret != null && !attempt.alive.error && attempt.alive.authentication) {
 				try {
-					attempt.authResponse = Pipeline2HttpClient.get(url, "", authid, secret, null);
+					attempt.authResponse = Pipeline2HttpClient.get(url, "/jobs", authid, secret, null);
 					//attempt.authResponse = org.daisy.pipeline.client.Scripts.get(url, authid, secret);
 					if (attempt.authResponse.status == 401) {
 						attempt.authError = "Invalid authentication ID or secret text";

--- a/webui/build.sbt
+++ b/webui/build.sbt
@@ -191,7 +191,7 @@ libraryDependencies ++= Seq(
   "org.apache.derby" % "derby" % "10.11.1.1",
   "mysql" % "mysql-connector-java" % "8.0.15",
   "org.daisy.pipeline" % "clientlib-java" % "5.0.0",
-  "org.daisy.pipeline" % "clientlib-java-httpclient" % "2.1.1",
+  "org.daisy.pipeline" % "clientlib-java-httpclient" % "2.1.2-SNAPSHOT",
   "org.apache.commons" % "commons-compress" % "1.9",
   "org.apache.commons" % "commons-email" % "1.4",
   "log4j" % "log4j" % "1.2.17",


### PR DESCRIPTION
Hi @bertfrees 

I've been working on helping @josteinaj  to set up login flow for their pipeline installation. We ran into a wall when you could not set up an API connection with authid and secret key and I guess it is because it's not using an URL encoded Base64 string for signing. 

This PR is trying to resolve this issue. I've separated it into two different commits. The first one was all changes that were required for me in order to build the Pipeline webservice and webui. Some SNAPSHOT version changes and also I changed to the new URI for restlet required of some packages.

More over I added the feature to create a zip file of the webui package. Not required so I can remove that change if you like.

The next commit is all code changes. Mainly I've changed to use the Base64.getUrlEncoder().withoutPadding().encode() for the hash that should be compared, this makes the process more reliable. I also had to change the UI component verifying the login to use a known endpoint like `/jobs` using the default root it never ran any login flow and always returned 404 so the webui could never have worked with authid and secret key.

I hope that these changes are OK, I understand that changing the API could be bad if a lot of people have implemented it against the old one and if so we could gradually change or just implement the change with the endpoint to ensure that the webui works. Then again @josteinaj could not reliably get the API to work.

Best regards
Daniel