### PR TITLE
Proposal : adding windows drives test for ConfigReader URI resolver

### DIFF
--- a/modules/tts/tts-common/src/main/java/org/daisy/pipeline/tts/config/ConfigReader.java
+++ b/modules/tts/tts-common/src/main/java/org/daisy/pipeline/tts/config/ConfigReader.java
@@ -69,10 +69,27 @@ public class ConfigReader implements ConfigProperties {
 	}
 
 	static public URL URIinsideConfig(String pathOrURI, URI relativeTo) {
-		URI uri= null;
-		if (pathOrURI.startsWith("/")) {
+		URI uri = null;
+		
+		// absolute path check
+		if(System.getProperty("os.name").toLowerCase().startsWith("windows")){
+			// on windows machine, test for each drive, 
+			for(File root : File.listRoots()){
+				String rootDrive = root.getAbsolutePath().split(":")[0] + ":";
+				if (pathOrURI.startsWith(rootDrive)) {
+					uri = URLs.asURI(new File(pathOrURI));
+					break;
+				} else if (pathOrURI.startsWith("/") && System.getenv("SYSTEMDRIVE").equals(rootDrive)){
+					uri = URLs.asURI(new File(rootDrive + pathOrURI));
+				}
+			}
+		} else if (pathOrURI.startsWith("/")) {
+			// test for unix machine
 			uri = URLs.asURI(new File(pathOrURI));
-		} else {
+		} 
+		
+		
+		if(uri == null) {
 			try {
 				uri = URLs.asURI(pathOrURI);
 			} catch (Exception e) {

--- a/modules/tts/tts-common/src/test/java/org/daisy/pipeline/tts/config/URITest.java
+++ b/modules/tts/tts-common/src/test/java/org/daisy/pipeline/tts/config/URITest.java
@@ -12,8 +12,14 @@ public class URITest {
 	@Test
 	public void absolutePath() {
 		URL url = ConfigReader.URIinsideConfig("/foo/bar.xml", null);
-		Assert.assertTrue("file:///foo/bar.xml".equals(url.toString())
-		        || "file:/foo/bar.xml".equals(url.toString()));
+		String systemRoot = "/";
+		if(System.getProperty("os.name").toLowerCase().startsWith("windows")){
+			systemRoot = "/" + System.getenv("SYSTEMDRIVE") + "/";
+		}
+		
+		Assert.assertTrue(
+			("file://"+ systemRoot+ "foo/bar.xml").equals(url.toString())
+		        || ("file:" +systemRoot+ "foo/bar.xml").equals(url.toString()));
 	}
 
 	@Test


### PR DESCRIPTION
On windows system, the tts-common project is not passing the URITest.absolutePath test due to unix system root used for the test.

I propose the following changes to make the test path and extend absolute URI resolution for windows system :
- in URIInsideConfig method of ConfigReader  :
  - Checking for windows drives in the path
  - Adding a default mapping between unix root and windows system drive

URITest class is also changed to consider windows subsystem for the absolutPath test
