### PR TITLE
[modules] dtbook-to-rtf: add missing px:type

### DIFF
--- a/modules/scripts/dtbook-to-rtf/src/main/resources/xml/dtbook-to-rtf.xpl
+++ b/modules/scripts/dtbook-to-rtf/src/main/resources/xml/dtbook-to-rtf.xpl
@@ -50,14 +50,14 @@
 		</p:documentation>
 	</p:input>
 
-	<p:option name="include-table-of-content" required="false" select="'false'">
+	<p:option name="include-table-of-content" px:type="boolean" required="false" select="'false'">
 		<p:documentation>
 			<h2 px:role="name">Include table of content</h2>
 			<p px:role="desc">A boolean indicating if a TOC should be generated.</p>
 		</p:documentation>
 	</p:option>
 
-	<p:option name="include-page-number" required="false" select="'false'">
+	<p:option name="include-page-number" px:type="boolean" required="false" select="'false'">
 		<p:documentation>
 			<h2 px:role="name">Include page number</h2>
 			<p px:role="desc">A boolean indicating if a TOC should be generated.</p>


### PR DESCRIPTION
Adding boolean type to options of dtbook-to-rtf.xpl script to correct the form rendering in UI