### PR TITLE
fix set-doctype: close the input stream reader before replacing the file

### DIFF
--- a/modules/common/file-utils/src/main/java/org/daisy/pipeline/file/calabash/impl/SetDoctypeProvider.java
+++ b/modules/common/file-utils/src/main/java/org/daisy/pipeline/file/calabash/impl/SetDoctypeProvider.java
@@ -135,6 +135,12 @@ public class SetDoctypeProvider implements XProcStepProvider {
 				} catch (IOException e) {
 					logger.error("SetDoctype: unable to close OutputStreamWriter", e);
 				}
+
+				try {
+					reader.close();
+				} catch (IOException e) {
+					logger.error("SetDoctype: unable to close InputStreamReader", e);
+				}
 				
 				if (success) {
 				    Files.move(tempFile.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);


### PR DESCRIPTION
Quick fix for an error in the SetDoctypeProvider class on Windows system (as reported in daisy/pipeline-modules#77) :
A Files.move operation was done to replace a file that was still opened through an InputStreamReader object and locked by the OS.

(tested in production, no error reported after the fix)