### PR TITLE
Text-to-speech adapter for Amazon Polly

### DIFF
--- a/modules/bom/pom.xml
+++ b/modules/bom/pom.xml
@@ -23,6 +23,7 @@
     <pdfbox.version>2.0.24</pdfbox.version>
     <poi.version>5.0.0</poi.version>
     <libreoffice.version>24.2.3</libreoffice.version>
+    <awssdk.version>2.31.45</awssdk.version>
   </properties>
 
   <dependencyManagement>
@@ -454,6 +455,11 @@
       </dependency>
       <dependency>
         <groupId>org.daisy.pipeline.modules</groupId>
+        <artifactId>tts-adapter-aws</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.daisy.pipeline.modules</groupId>
         <artifactId>tts-adapter-azure</artifactId>
         <version>1.1.3</version>
       </dependency>
@@ -711,6 +717,144 @@
         <groupId>com.microsoft.cognitiveservices.speech</groupId>
         <artifactId>client-sdk</artifactId>
         <version>1.37.0</version>
+      </dependency>
+      <!--
+          for tts-adapter-aws
+      -->
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>polly</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>sdk-core</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>auth</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>identity-spi</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>http-auth</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>http-auth-aws</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>http-auth-spi</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>http-client-spi</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>apache-client</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>aws-core</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>utils</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>regions</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>aws-json-protocol</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>retries</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>retries-spi</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>profiles</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>endpoints-spi</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>metrics-spi</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>protocol-core</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>aws-json-protocol</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>json-utils</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>third-party-jackson-core</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>checksums</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>checksums-spi</artifactId>
+        <version>${awssdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.reactivestreams</groupId>
+        <artifactId>reactive-streams</artifactId>
+        <version>1.0.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.reactivestreams</groupId>
+        <artifactId>reactive-streams-tck</artifactId>
+        <version>1.0.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.reactivestreams</groupId>
+        <artifactId>reactive-streams-tck-flow</artifactId>
+        <version>1.0.4</version>
       </dependency>
       <!--
           for audio-common

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -66,6 +66,7 @@
     <module>tts/tts-adapters/tts-adapter-google</module>
     <module>tts/tts-adapters/tts-adapter-cereproc</module>
     <module>tts/tts-adapters/tts-adapter-azure</module>
+    <module>tts/tts-adapters/tts-adapter-aws</module>
     <module>tts/tts-mocks</module>
     <module>tts/mathml-to-ssml</module>
     <module>braille/braille-common</module>

--- a/modules/tts/tts-adapters/tts-adapter-aws/README.md
+++ b/modules/tts/tts-adapters/tts-adapter-aws/README.md
@@ -1,0 +1,28 @@
+# AWS Polly Text-To-Speech Adapter
+
+This adapter provides a way to use the Amazon Web Service - Polly Text-to-Speech service in the pipeline. It is based on the [AWS SDK for Java](https://aws.amazon.com/sdk-for-java/) and the [AWS Polly API](https://docs.aws.amazon.com/polly/latest/dg/what-is.html).
+
+## New properties
+
+The following properties are used by this adapter:
+
+- `org.daisy.pipeline.tts.aws.accesskey` (mandatory) : Access key to connect to Amazon Web Service.
+- `org.daisy.pipeline.tts.aws.secretkey` (mandatory) : Secret key to connect to Amazon Web Service.
+- `org.daisy.pipeline.tts.aws.region` (mandatory) : Region associated with your Amazon Web Service account.
+- `org.daisy.pipeline.tts.aws.priority` (defaults to `15`) : priority of usage within the pipeline if other text engine are available
+
+## Usage
+
+This adapter requires authentication keys (namely an access key and a secret key) to access the AWS Polly service.
+
+To get those keys, you will need to create an AWS account and a "IAM user" account, or a root user registered in an instance of an IAM identity center. To create such user account, please refer to the [AWS IAM user creation documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html).
+Note that while it is not recommended, you can also use your root account to generate the required keys, as explained in [this AWS documention page](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user_manage_add-key.html).
+
+From the IAM User account or your root, you should be able to create access and secret keys by following the instructions in the [AWS IAM user documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access-key-self-managed.html).
+
+You should be able to retrieve the region identifier from your associated IAM identity center instance.
+As an example for europe/paris, it would be displayed as `eu-west-3`.
+
+## Tests
+
+For unit test to work, please add the required properties mentionned above (`org.daisy.pipeline.tts.aws.{accesskey,secretkey,region}`) to either your configuration or pom, or add the options `-Dorg.daisy.pipeline.tts.aws.accesskey="your_access_key" -Dorg.daisy.pipeline.tts.aws.secretkey="your_secret_key" -Dorg.daisy.pipeline.tts.aws.region="your_region"` to your maven call. 

--- a/modules/tts/tts-adapters/tts-adapter-aws/pom.xml
+++ b/modules/tts/tts-adapters/tts-adapter-aws/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.daisy.pipeline.modules</groupId>
+    <artifactId>modules-parent</artifactId>
+    <version>1.15.0</version>
+    <relativePath>../../../parent</relativePath>
+  </parent>
+
+  <version>1.0.0-SNAPSHOT</version>
+  <artifactId>tts-adapter-aws</artifactId>
+  <packaging>bundle</packaging>
+
+  <name>DAISY Pipeline 2 module :: TTS Adapter for Amazon Polly text-to-speech service</name>
+  <description>Implementation of the TTS API for Amazon Polly text-to-speech service</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.daisy.pipeline.modules</groupId>
+      <artifactId>tts-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.daisy.libs</groupId>
+      <artifactId>saxon-he</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>polly</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <expose-services>
+      org.daisy.pipeline.tts.aws.impl.AWSPollyTTSService
+    </expose-services>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Import-Package>
+              net.sf.saxon.*;version="${saxon.versionRange}",
+              !org.daisy.common.spi,
+              *
+            </Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <org.daisy.pipeline.tts.aws.accesskey>ToBeSetForTests</org.daisy.pipeline.tts.aws.accesskey>
+            <org.daisy.pipeline.tts.aws.secretkey>ToBeSetForTests</org.daisy.pipeline.tts.aws.secretkey>
+            <org.daisy.pipeline.tts.aws.region>ToBeSetForTests</org.daisy.pipeline.tts.aws.region>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/modules/tts/tts-adapters/tts-adapter-aws/src/main/java/org/daisy/pipeline/tts/aws/impl/AWSPollyTTSEngine.java
+++ b/modules/tts/tts-adapters/tts-adapter-aws/src/main/java/org/daisy/pipeline/tts/aws/impl/AWSPollyTTSEngine.java
@@ -1,0 +1,183 @@
+package org.daisy.pipeline.tts.aws.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import static java.util.stream.Collectors.toList;
+
+import javax.sound.sampled.AudioFormat;
+
+import com.google.common.io.ByteStreams;
+
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.XdmNode;
+
+import org.daisy.common.file.URLs;
+import org.daisy.pipeline.tts.TTSEngine;
+import org.daisy.pipeline.tts.TTSRegistry;
+import org.daisy.pipeline.tts.TTSService.SynthesisException;
+import org.daisy.pipeline.tts.Voice;
+import org.daisy.pipeline.tts.VoiceInfo.Gender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.core.exception.AbortedException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.polly.PollyClient;
+import software.amazon.awssdk.services.polly.model.DescribeVoicesResponse;
+import software.amazon.awssdk.services.polly.model.SynthesizeSpeechRequest;
+import software.amazon.awssdk.services.polly.model.Engine;
+import software.amazon.awssdk.services.polly.model.TextType;
+import software.amazon.awssdk.services.polly.model.VoiceId;
+import software.amazon.awssdk.services.polly.model.OutputFormat;
+
+/**
+ * TTS adapter for Amazon Polly
+ * @author mmartida - original author
+ * @author Nicolas Pavie - updates and refactoring for DAISY Pipeline 2, version 1.15+
+ */
+public class AWSPollyTTSEngine extends TTSEngine {
+
+	private final static URL SSML_TRANSFORMER = URLs.getResourceFromJAR("/transform-ssml.xsl", AWSPollyTTSEngine.class);
+
+	private final static Logger LOGGER = LoggerFactory.getLogger(AWSPollyTTSEngine.class);
+
+	private static final AudioFormat AF_PCM_POLLY = new AudioFormat(AudioFormat.Encoding.PCM_SIGNED, 16000f, 16, 1, 2, 16000f, false);
+
+	/**
+	 * Client object provided by AWS SDK to interact with the polly engines
+	 */
+	private final PollyClient client;
+
+	/**
+	 * Map of AWS voices available to the user for each engine
+	 */
+	private final HashMap<Engine, DescribeVoicesResponse> awsVoicesDescription = new HashMap<>();
+
+	private int mPriority;
+
+	/**
+	 * Constructor for the AWSPollyTTSEngine
+	 *
+	 * @param service the bound service
+	 * @param accessKey the AWS account access key
+	 * @param secretKey the AWS account secret key
+	 * @param region the AWS region
+	 * @throws SynthesisException
+	 */
+	public AWSPollyTTSEngine(AWSPollyTTSService service, String accessKey, String secretKey, String region, int priority)
+			throws SynthesisException {
+
+		super(service);
+		this.client = PollyClient.builder()
+			.credentialsProvider(() -> new AwsCredentials() {
+				@Override
+				public String accessKeyId() {
+					return accessKey;
+				}
+
+				@Override
+				public String secretAccessKey() {
+					return secretKey;
+				}
+			})
+			.region(Region.of(region))
+			.build();
+		this.mPriority = priority;
+	}
+
+
+	/**
+	 * Get the list of available voices
+	 *
+	 * @throws SynthesisException
+	 * @throws InterruptedException
+	 */
+	@Override
+	public Collection<Voice> getAvailableVoices() throws SynthesisException, InterruptedException {
+		Collection<Voice> voices = new ArrayList<>();
+		if(awsVoicesDescription.isEmpty()){
+			// fetch all voices for all engines
+			for (Engine engine : Engine.knownValues()) {
+				try {
+					DescribeVoicesResponse awsvoices = this.client.describeVoices(b -> b.engine(engine));
+					awsVoicesDescription.put(engine, awsvoices);
+				} catch (Exception e) {
+					LOGGER.error("Error fetching AWS voices for engine {}: {}", engine, e.getMessage());
+				}
+			}
+		}
+		for (DescribeVoicesResponse awsvoices : awsVoicesDescription.values()) {
+			voices.addAll(
+				awsvoices.voices()
+				.stream()
+				.map(i -> new Voice("polly",
+				                    i.name(),
+				                    new Locale(i.languageName()),
+				                    Gender.of(i.genderAsString().toLowerCase())))
+				.collect(toList())
+			);
+		}
+		return voices;
+	}
+
+	@Override
+	public SynthesisResult synthesize(XdmNode pXdmNode, Voice pVoice, TTSRegistry.TTSResource pTTSResource)
+			throws SynthesisException, InterruptedException {
+
+		String sentence; {
+			try {
+				Map<String,Object> params = new HashMap<>(); {}
+				sentence = transformSsmlNodeToString(pXdmNode, SSML_TRANSFORMER, params);
+			} catch (IOException | SaxonApiException e) {
+				throw new SynthesisException(e);
+			}
+		}
+		try {
+			SynthesizeSpeechRequest synthReq = SynthesizeSpeechRequest.builder()
+				.engine(Engine.STANDARD)
+				.text(sentence)
+				.textType(TextType.SSML)
+				.voiceId(
+					VoiceId.fromValue(pVoice.getName())
+				)
+				.outputFormat(OutputFormat.PCM)
+				.build();
+			return new SynthesisResult(
+				createAudioStream(
+					AF_PCM_POLLY, new ByteArrayInputStream(
+						ByteStreams.toByteArray(this.client.synthesizeSpeech(synthReq))
+					)
+				)
+			);
+		} catch (IOException ex) {
+			throw new SynthesisException("Could not synthesize sentence \"" + sentence + "\"", ex);
+		} catch (AbortedException e) {
+			if (Thread.currentThread().isInterrupted()) {
+				InterruptedException ex = new InterruptedException();
+				ex.initCause(e);
+				throw ex;
+			} else {
+				throw e;
+			}
+		}
+	}
+
+	@Override
+	public int getOverallPriority() {
+		return mPriority;
+	}
+
+	@Override
+	public int expectedMillisecPerWord() {
+		// Worst case scenario with quotas:
+		// the thread can wait for a bit more than a minute for a anwser
+		return 10000;
+	}
+}

--- a/modules/tts/tts-adapters/tts-adapter-aws/src/main/java/org/daisy/pipeline/tts/aws/impl/AWSPollyTTSService.java
+++ b/modules/tts/tts-adapters/tts-adapter-aws/src/main/java/org/daisy/pipeline/tts/aws/impl/AWSPollyTTSService.java
@@ -81,7 +81,7 @@ public class AWSPollyTTSService implements TTSService {
 
 	@Override
 	public String getName() {
-		return "polly";
+		return "aws";
 	}
 
 	@Override

--- a/modules/tts/tts-adapters/tts-adapter-aws/src/main/java/org/daisy/pipeline/tts/aws/impl/AWSPollyTTSService.java
+++ b/modules/tts/tts-adapters/tts-adapter-aws/src/main/java/org/daisy/pipeline/tts/aws/impl/AWSPollyTTSService.java
@@ -46,7 +46,7 @@ public class AWSPollyTTSService implements TTSService {
 		true,
 		"Priority of Amazon voices relative to voices of other engines",
 		false,
-		"2");
+		"15");
 
 	@Override
 	public AWSPollyTTSEngine newEngine(Map<String,String> properties)

--- a/modules/tts/tts-adapters/tts-adapter-aws/src/main/java/org/daisy/pipeline/tts/aws/impl/AWSPollyTTSService.java
+++ b/modules/tts/tts-adapters/tts-adapter-aws/src/main/java/org/daisy/pipeline/tts/aws/impl/AWSPollyTTSService.java
@@ -1,0 +1,91 @@
+package org.daisy.pipeline.tts.aws.impl;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.daisy.common.properties.Properties;
+import org.daisy.common.properties.Properties.Property;
+import org.daisy.pipeline.tts.TTSService;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author mmartida - original author
+ * @author Nicolas Pavie - update for pipeline-modules 1.15+
+ */
+@Component(
+	name = "aws-tts-service",
+	service = { TTSService.class }
+)
+public class AWSPollyTTSService implements TTSService {
+
+	private static final Property AWS_ACCESS_KEY = Properties.getProperty(
+		"org.daisy.pipeline.tts.aws.accesskey",
+		true,
+		"Access key for Amazon Polly speech engine",
+		true,
+		null
+	);
+
+	private static final Property AWS_SECRET_KEY = Properties.getProperty(
+		"org.daisy.pipeline.tts.aws.secretkey",
+		true,
+		"Secret key for Amazon Polly speech engine",
+		true,
+		null);
+
+	private static final Property AWS_REGION = Properties.getProperty(
+		"org.daisy.pipeline.tts.aws.region",
+		true,
+		"Region for Amazon Polly speech engine",
+		true,
+		null);
+
+	private static final Property AWS_PRIORITY = Properties.getProperty(
+		"org.daisy.pipeline.tts.aws.priority",
+		true,
+		"Priority of Amazon voices relative to voices of other engines",
+		false,
+		"2");
+
+	@Override
+	public AWSPollyTTSEngine newEngine(Map<String,String> properties)
+			throws ServiceDisabledException, SynthesisException {
+
+		String accessKey = AWS_ACCESS_KEY.getValue(properties);
+		if (accessKey == null || "".equals(accessKey))
+			throw new ServiceDisabledException("Property not set: " + AWS_ACCESS_KEY.getName());
+		String secretKey = AWS_SECRET_KEY.getValue(properties);
+		if (secretKey == null || "".equals(secretKey))
+			throw new ServiceDisabledException("Property not set: " + AWS_SECRET_KEY.getName());
+		String region = AWS_REGION.getValue(properties);
+		if (region == null || "".equals(region))
+			throw new ServiceDisabledException("Property not set: " + AWS_REGION.getName());
+		int priority = getPropertyAsInt(properties, AWS_PRIORITY).get();
+		return new AWSPollyTTSEngine(this, accessKey, secretKey, region, priority);
+	}
+
+	private static Optional<Integer> getPropertyAsInt(Map<String,String> properties, Property prop)
+			throws SynthesisException {
+
+		String str = prop.getValue(properties);
+		if (str != null) {
+			try {
+				return Optional.of(Integer.valueOf(str));
+			} catch (NumberFormatException e) {
+				throw new SynthesisException(str + " is not a valid a value for property " + prop.getName());
+			}
+		}
+		return Optional.empty();
+	}
+
+	@Override
+	public String getName() {
+		return "polly";
+	}
+
+	@Override
+	public String getDisplayName() {
+		return "Amazon";
+	}
+}

--- a/modules/tts/tts-adapters/tts-adapter-aws/src/main/resources/transform-ssml.xsl
+++ b/modules/tts/tts-adapters/tts-adapter-aws/src/main/resources/transform-ssml.xsl
@@ -8,6 +8,10 @@
   <xsl:param name="voice" select="''"/>
   <xsl:param name="ending-mark" select="''"/>
 
+  <!-- Amazon does not like id on sentences ... -->
+  <xsl:template match="@*:id" />
+  <xsl:template match="@*:id" mode="copy"/>
+
   <xsl:template match="*">
     <speak version="1.0">
       <xsl:apply-templates select="if (local-name()='speak') then node() else ." mode="copy"/>

--- a/modules/tts/tts-adapters/tts-adapter-aws/src/main/resources/transform-ssml.xsl
+++ b/modules/tts/tts-adapters/tts-adapter-aws/src/main/resources/transform-ssml.xsl
@@ -1,0 +1,36 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns="http://www.w3.org/2001/10/synthesis"
+                exclude-result-prefixes="#all">
+
+  <xsl:output omit-xml-declaration="yes"/>
+
+  <xsl:param name="voice" select="''"/>
+  <xsl:param name="ending-mark" select="''"/>
+
+  <xsl:template match="*">
+    <speak version="1.0">
+      <xsl:apply-templates select="if (local-name()='speak') then node() else ." mode="copy"/>
+      <break time="250ms"/>
+      <xsl:if test="$ending-mark != ''">
+	<mark name="{$ending-mark}"/>
+      </xsl:if>
+    </speak>
+  </xsl:template>
+
+  <xsl:template match="@*|node()" mode="copy">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" mode="copy"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="@xml:lang" mode="copy">
+    <!-- not copied in order to prevent inconsistency with the current voice -->
+  </xsl:template>
+
+  <xsl:template match="token" mode="copy">
+    <!-- tokens are not copied because they are not SSML1.0-compliant and not SAPI-compliant -->
+    <xsl:apply-templates select="node()" mode="copy"/>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/modules/tts/tts-adapters/tts-adapter-aws/src/test/java/ignore
+++ b/modules/tts/tts-adapters/tts-adapter-aws/src/test/java/ignore
@@ -1,0 +1,1 @@
+org/daisy/pipeline/tts/aws/impl/AWSPollyTTSServiceTest.java

--- a/modules/tts/tts-adapters/tts-adapter-aws/src/test/java/org/daisy/pipeline/tts/aws/impl/AWSPollyTTSServiceTest.java
+++ b/modules/tts/tts-adapters/tts-adapter-aws/src/test/java/org/daisy/pipeline/tts/aws/impl/AWSPollyTTSServiceTest.java
@@ -76,11 +76,8 @@ public class AWSPollyTTSServiceTest {
 		TTSResource resource = engine.allocateThreadResources();
 		try {
 			TTSEngine.SynthesisResult res = engine.synthesize(
-					// con este texto falla. Es lo que le llega desde la aplicación para probar el engine y está fallando.
-//					"<ssml:speak xmlns:ssml=\"http://www.w3.org/2001/10/synthesis\" version=\"1.0\"><s:s xmlns:tmp=\"http://\" xmlns:s=\"http://www.w3.org/2001/10/synthesis\" >small sentence</s:s><ssml:break time=\"250ms\"/></ssml:speak>",
-					// con esto funciona. Parece que no le gustan los namespaces.
-				parseSSML("<ssml:speak xmlns:ssml=\"http://www.w3.org/2001/10/synthesis\" version=\"1.0\"><s xmlns=\"http://www.w3.org/2001/10/synthesis\">García, que de humor iba justito cuando era el inocente, entró una vez a un trapo que no ayudó a la fluidez de su relación tempestuosa con Gil.</s><ssml:break time=\"250ms\"/></ssml:speak>"),
-				new Voice("polly", "Lucia"), resource
+				parseSSML("<ssml:speak xmlns:ssml=\"http://www.w3.org/2001/10/synthesis\" version=\"1.0\"><s xmlns=\"http://www.w3.org/2001/10/synthesis\" id=\"1\">García, que de humor iba justito cuando era el inocente, entró una vez a un trapo que no ayudó a la fluidez de su relación tempestuosa con Gil.</s><ssml:break time=\"250ms\"/></ssml:speak>"),
+				new Voice("aws", "Lucia (standard)"), resource
 			);
 
 			AudioFormat format = res.audio.getFormat();

--- a/modules/tts/tts-adapters/tts-adapter-aws/src/test/java/org/daisy/pipeline/tts/aws/impl/AWSPollyTTSServiceTest.java
+++ b/modules/tts/tts-adapters/tts-adapter-aws/src/test/java/org/daisy/pipeline/tts/aws/impl/AWSPollyTTSServiceTest.java
@@ -1,0 +1,92 @@
+package org.daisy.pipeline.tts.aws.impl;
+
+import java.io.StringReader;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioInputStream;
+import javax.xml.transform.sax.SAXSource;
+
+import net.sf.saxon.s9api.Processor;
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.XdmNode;
+
+import org.daisy.pipeline.tts.TTSEngine;
+import org.daisy.pipeline.tts.TTSRegistry.TTSResource;
+import org.daisy.pipeline.tts.Voice;
+
+import org.xml.sax.InputSource;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AWSPollyTTSServiceTest {
+
+	@Before
+	public void checkConfig() {
+		String prop = "org.daisy.pipeline.tts.aws.accesskey";
+		if (System.getProperty(prop) == null) {
+			System.out.println("No access key provided, please set the " + prop + " property");
+		}
+		Assume.assumeTrue(System.getProperty(prop) != null);
+		prop = "org.daisy.pipeline.tts.aws.secretkey";
+		if (System.getProperty(prop) == null) {
+			System.out.println("No secret key provided, please set the " + prop + " property");
+		}
+		Assume.assumeTrue(System.getProperty(prop) != null);
+		prop = "org.daisy.pipeline.tts.aws.region";
+		if (System.getProperty(prop) == null) {
+			System.out.println("No region provided, please set the " + prop + " property");
+		}
+		Assume.assumeTrue(System.getProperty(prop) != null);
+	}
+
+	private static AWSPollyTTSEngine allocateEngine() throws Throwable {
+		Map<String,String> params = new HashMap<>(); {
+			params.put("org.daisy.pipeline.tts.aws.accesskey", System.getProperty("org.daisy.pipeline.tts.aws.accesskey"));
+			params.put("org.daisy.pipeline.tts.aws.secretkey", System.getProperty("org.daisy.pipeline.tts.aws.secretkey"));
+			params.put("org.daisy.pipeline.tts.aws.region", System.getProperty("org.daisy.pipeline.tts.aws.region"));
+		}
+		return new AWSPollyTTSService().newEngine(params);
+	}
+
+	private static int getSize(AudioInputStream audio) {
+		return Math.toIntExact(audio.getFrameLength() * audio.getFormat().getFrameSize());
+	}
+
+	private static final Processor proc = new Processor(false);
+	private static XdmNode parseSSML(String ssml) throws SaxonApiException {
+		return proc.newDocumentBuilder().build(new SAXSource(new InputSource(new StringReader(ssml))));
+	}
+
+	@Test
+	public void testAvailableVoices() throws Throwable {
+		TTSEngine engine = allocateEngine();
+		Collection<Voice> voices = engine.getAvailableVoices();
+		Assert.assertTrue(voices.size() > 0);
+	}
+
+	@Test
+	public void testSpeak() throws Throwable {
+		TTSEngine engine = allocateEngine();
+		TTSResource resource = engine.allocateThreadResources();
+		try {
+			TTSEngine.SynthesisResult res = engine.synthesize(
+					// con este texto falla. Es lo que le llega desde la aplicación para probar el engine y está fallando.
+//					"<ssml:speak xmlns:ssml=\"http://www.w3.org/2001/10/synthesis\" version=\"1.0\"><s:s xmlns:tmp=\"http://\" xmlns:s=\"http://www.w3.org/2001/10/synthesis\" >small sentence</s:s><ssml:break time=\"250ms\"/></ssml:speak>",
+					// con esto funciona. Parece que no le gustan los namespaces.
+				parseSSML("<ssml:speak xmlns:ssml=\"http://www.w3.org/2001/10/synthesis\" version=\"1.0\"><s xmlns=\"http://www.w3.org/2001/10/synthesis\">García, que de humor iba justito cuando era el inocente, entró una vez a un trapo que no ayudó a la fluidez de su relación tempestuosa con Gil.</s><ssml:break time=\"250ms\"/></ssml:speak>"),
+				new Voice("polly", "Lucia"), resource
+			);
+
+			AudioFormat format = res.audio.getFormat();
+			Assert.assertTrue(getSize(res.audio) > 10000);
+		} finally {
+			engine.releaseThreadResources(resource);
+		}
+	}
+}

--- a/modules/tts/tts-adapters/tts-adapter-aws/src/test/resources/logback.xml
+++ b/modules/tts/tts-adapters/tts-adapter-aws/src/test/resources/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+  <include file="../../../logback.xml"/>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.apache.http" level="WARN"/>
+  <logger name="software.amazon.awssdk.auth" level="INFO"/>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
This PR integrates the text-to-speech adapter for Amazon Polly engines into the DAISY Pipeline 2 modules tree.

Original code was authored by @mmartida and provided by [ONCE](https://www.once.es/) to the DAISY Pipeline team.
The adapter was then updated for the latest version of Daisy Pipeline 2 and refactored to match similar adapters structure (mainly azure and google TTS adapters).

The adapter has also been updated to allow the use of generative, long-form, or neural voices if available for the user's AWS account.

The following properties are used by the adapter :
- `org.daisy.pipeline.tts.aws.accesskey` (mandatory) : Access key to connect to Amazon Web Service.
- `org.daisy.pipeline.tts.aws.secretkey` (mandatory) : Secret key to connect to Amazon Web Service.
- `org.daisy.pipeline.tts.aws.region` (mandatory) : Region associated with your Amazon Web Service account.
- `org.daisy.pipeline.tts.aws.priority` (defaults to `15`) : priority of usage within the pipeline if other text engine are available

The adapter relies on AWS java Polly client library. All dependencies required for its usage are added to the `modules/bom` project.

In case it would be preferable to release the adapter on maven before including it's first release version, this PR :
- Does not register the adapter itself in the `modules/bom`
- Does not include the aforementioned dependencies and the new adapter in the current assembly project

(@bertfrees I'll leave you the squashing and rephrase for the pipeline history depending on how you want it merged in)